### PR TITLE
Rename repository as `transfermarkt-datasets`

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,4 @@
 [core]
     remote = s3
 ['remote "s3"']
-    url = s3://player-scores/dvc
+    url = s3://transfermarkt-datasets/dvc

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         environment-file: environment.yml
-        activate-environment: player-scores
+        activate-environment: transfermarkt-datasets
     - name: sync datasets
       env:
         # Kaggle API auth

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         environment-file: environment.yml
-        activate-environment: player-scores
+        activate-environment: transfermarkt-datasets
     - name: Run pipeline
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/1_acquire.py
+++ b/1_acquire.py
@@ -47,7 +47,7 @@ ASSET_NAME = arguments.asset
 SCRAPY_CACHE = arguments.scrapy_cache
 DRY_RUN = os.environ.get('DRY_RUN')
 # identify this scraping jobs accordinly by setting a nice user agent
-USER_AGENT = 'player-scores/1.0 (https://github.com/dcaribou/player-scores)'
+USER_AGENT = 'transfermarkt-datasets/1.0 (https://github.com/dcaribou/transfermarkt-datasets)'
 CAT = arguments.cat
 
 class Asset():

--- a/3_sync.py
+++ b/3_sync.py
@@ -2,7 +2,7 @@
 Upload datasets to S3 storage and data hub websites.
 Publication to the following sites are supported:
 
-- S3: store scrapy cache and prepared files in s3://player-scores 
+- S3: store scrapy cache and prepared files in s3://transfermarkt-datasets 
 - Kaggle: update dataset 'davidcariboo/player-scores'
 - data.world: update dataset 'dcereijo/player-scores'
 
@@ -48,7 +48,7 @@ def save_to_s3(path, relative_to):
       max_concurrency=50
   )
 
-  bucket_name = 'player-scores'
+  bucket_name = 'transfermarkt-datasets'
 
   s3t = s3transfer.create_transfer_manager(s3_client, transfer_config)
 
@@ -106,7 +106,7 @@ def publish_to_dataworld(folder):
     presigned_url = s3_client.generate_presigned_url(
       'get_object',
       Params={
-        'Bucket': 'player-scores',
+        'Bucket': 'transfermarkt-datasets',
         'Key': 'snapshots/data/prep/' + resource['path']
       },
       ExpiresIn=50

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# :soccer: player-scores
+# transfermarkt-datasets
 Use data from [trasfermarkt-scraper](https://github.com/dcaribou/transfermarkt-scraper) to compute player's scores and forecast performance. Use forecasts to improve decision-making when creating line-ups for games such as [Fantasy Football](https://fantasy.premierleague.com/), [Biwenger](https://www.biwenger.com/), etc. 
 
 This is an **ongoing project** that aims to achieve this goal incrementally by
 
-- [x] Building a clean, public dataset of player appearances' statistics &#8594; [`dataset-improvements`](https://github.com/dcaribou/player-scores/issues?q=is%3Aissue+is%3Aopen+label%3A%22dataset+improvements%22)
+- [x] Building a clean, public dataset of player appearances' statistics &#8594; [`dataset-improvements`](https://github.com/dcaribou/transfermarkt-datasets/issues?q=is%3Aissue+is%3Aopen+label%3A%22dataset+improvements%22)
 - [ ] Training a machine learning model that uses historical data to forecast player's performance on their next game &#8594; [`machine-learning`](https://github.com/dcaribou/player-scores/issues?q=is%3Aissue+is%3Aopen+label%3A%22machine+learning%22)
-- [ ] Create a line-up analysis tool by displaying forecasts on a dashboard &#8594; [`visualization`](https://github.com/dcaribou/player-scores/issues?q=is%3Aissue+is%3Aopen+label%3Avisualizations)
+- [ ] Create a line-up analysis tool by displaying forecasts on a dashboard &#8594; [`visualization`](https://github.com/dcaribou/transfermarkt-datasets/issues?q=is%3Aissue+is%3Aopen+label%3Avisualizations)
 
 ### [data](data)
 All project data assets are kept inside the `data` folder. This is a [DVC](https://dvc.org/) repository, therefore all files for the current revision can be pulled from remote storage with the `dvc pull` command.
 
-> :information_source: Read access to the [DVC remote storage](https://dvc.org/doc/command-reference/remote#description) for this project is required to successfully run `dvc pull`. Contributors should feel free to grant themselves access by adding their AWS IAM user ARN to [this whitelist](https://github.com/dcaribou/player-scores/blob/f5bda59b3a4fccf71fcef5a165591d441ab75e2d/infra/main.tf#L16). Have a look at [this PR](https://github.com/dcaribou/player-scores/pull/47/files) for an example.
+> :information_source: Read access to the [DVC remote storage](https://dvc.org/doc/command-reference/remote#description) for this project is required to successfully run `dvc pull`. Contributors should feel free to grant themselves access by adding their AWS IAM user ARN to [this whitelist](https://github.com/dcaribou/transfermarkt-datasets/blob/f5bda59b3a4fccf71fcef5a165591d441ab75e2d/infra/main.tf#L16). Have a look at [this PR](https://github.com/dcaribou/transfermarkt-datasets/pull/47/files) for an example.
 
 ### [prep](prep)
 Scripts for transforming scraped data into a cleaned, validated [data package](https://specs.frictionlessdata.io/) that can be used as the basis of further analysis in this project. For reference, checkout prepared datasets are published at

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # transfermarkt-datasets
-Use data from [trasfermarkt-scraper](https://github.com/dcaribou/transfermarkt-scraper) to compute player's scores and forecast performance. Use forecasts to improve decision-making when creating line-ups for games such as [Fantasy Football](https://fantasy.premierleague.com/), [Biwenger](https://www.biwenger.com/), etc. 
+Use data from [trasfermarkt-scraper](https://github.com/dcaribou/transfermarkt-scraper) to **build a clean, public football (soccer) dataset**. This includes data as clubs, games, players and player appearances from a number of national and international competitions and seasons.
 
-This is an **ongoing project** that aims to achieve this goal incrementally by
+Automate the data pipeline to **keep these assets up to date** and publicly available on well-known data catalogs for the data community's convenience.
 
-- [x] Building a clean, public dataset of player appearances' statistics &#8594; [`dataset-improvements`](https://github.com/dcaribou/transfermarkt-datasets/issues?q=is%3Aissue+is%3Aopen+label%3A%22dataset+improvements%22)
-- [ ] Training a machine learning model that uses historical data to forecast player's performance on their next game &#8594; [`machine-learning`](https://github.com/dcaribou/player-scores/issues?q=is%3Aissue+is%3Aopen+label%3A%22machine+learning%22)
-- [ ] Create a line-up analysis tool by displaying forecasts on a dashboard &#8594; [`visualization`](https://github.com/dcaribou/transfermarkt-datasets/issues?q=is%3Aissue+is%3Aopen+label%3Avisualizations)
+:white_check_mark: [Kaggle](https://www.kaggle.com/davidcariboo/player-scores) :white_check_mark: [data.world](https://data.world/dcereijo/player-scores)
 
 ### [data](data)
 All project data assets are kept inside the `data` folder. This is a [DVC](https://dvc.org/) repository, therefore all files for the current revision can be pulled from remote storage with the `dvc pull` command.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,19 @@ All project data assets are kept inside the `data` folder. This is a [DVC](https
 
 > :information_source: Read access to the [DVC remote storage](https://dvc.org/doc/command-reference/remote#description) for this project is required to successfully run `dvc pull`. Contributors should feel free to grant themselves access by adding their AWS IAM user ARN to [this whitelist](https://github.com/dcaribou/transfermarkt-datasets/blob/f5bda59b3a4fccf71fcef5a165591d441ab75e2d/infra/main.tf#L16). Have a look at [this PR](https://github.com/dcaribou/transfermarkt-datasets/pull/47/files) for an example.
 
+`raw` data within this folder can be updated by running the [trasfermarkt-scraper](https://github.com/dcaribou/transfermarkt-scraper) with the `1_acquire.py` script.
+```console
+$ python 1_acquire.py --asset all --season 2021
+```
+
 ### [prep](prep)
-Scripts for transforming scraped data into a cleaned, validated [data package](https://specs.frictionlessdata.io/) that can be used as the basis of further analysis in this project. For reference, checkout prepared datasets are published at
-* [Kaggle Datasets](https://www.kaggle.com/davidcariboo/player-scores)
-* [data.world Datasets](https://data.world/dcereijo/player-scores)
+Scripts for transforming scraped `raw` data into a cleaned, validated [data package](https://specs.frictionlessdata.io/) that can be used as the basis of further analysis in this project. You may run these scripts to produce the prepared dataset within `data/prep` using `2_prepare.py`.
+```console
+$ python 2_prepare.py [--raw-files-location data/raw]
+```
+For reference on the types of assets produced by this script checkout published datasets linked above.
+> :information_source: The preparation step uses `raw` data as input, hence raw files need to be available locally in order to run this step. You may pull raw assets by running `dvc pull` as mentioned earlier or by acquiring new and updated raw assets via `1_acquire.py` 
 
 ### [infra](infra)
-Define all the necessary infrastructure for the project in the cloud.
+Define all the necessary infrastructure for the project in the cloud with Terraform.
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: player-scores
+name: transfermarkt-datasets
 channels:
   - conda-forge
   - defaults

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -14,15 +14,15 @@ provider "aws" {
 # add your AWS IAM user ARN to this list to gain access to DVC remote storage
 locals {
   authorized_users = [
-    "arn:aws:iam::272181418418:user/player-scores"
+    "arn:aws:iam::272181418418:user/transfermarkt-datasets"
   ]
 }
 module "base" {
   source = "./base"
-  bucket_name = "player-scores"
-  user_name = "player-scores"
+  bucket_name = "transfermarkt-datasets"
+  user_name = "transfermarkt-datasets"
   authorized_users = local.authorized_users
   tags = {
-    "project" = "player-scores"
+    "project" = "transfermarkt-datasets"
   }
 }

--- a/notebooks/prep_playbook.ipynb
+++ b/notebooks/prep_playbook.ipynb
@@ -10,7 +10,7 @@
     "import os\n",
     "os.system(\"dvc pull\")\n",
     "\n",
-    "home = os.path.expanduser(\"~/player-scores\") \n",
+    "home = os.path.expanduser(\"~/transfermarkt-datasets\") \n",
     "os.chdir(home)"
    ]
   },

--- a/prep/datapackage_description.md
+++ b/prep/datapackage_description.md
@@ -8,13 +8,13 @@ For example, the `appearances.csv` file contains **one row per player appearance
 > **Idea:** Chekout the mate data.world project [Football Statistics from Transfermarkt](https://data.world/dcereijo/player-scores-demo) for examples of how to use the resources in this dataset to create different types of analysis.
 
 ### How did we build it?
-The source code that maintains this dataset [is available in Github](https://github.com/dcaribou/player-scores). On a high level, the project uses [transfermarkt-scraper](https://github.com/dcaribou/transfermarkt-scraper) to pull the data from [Transfermark website](https://www.transfermarkt.co.uk/) and a set of Python scripts to curate it and publish it here.
+The source code that maintains this dataset [is available in Github](https://github.com/dcaribou/transfermarkt-datasets). On a high level, the project uses [transfermarkt-scraper](https://github.com/dcaribou/transfermarkt-scraper) to pull the data from [Transfermark website](https://www.transfermarkt.co.uk/) and a set of Python scripts to curate it and publish it here.
 
-> **Idea:** Watch the [`player-scores` Github repository](https://github.com/dcaribou/player-scores) for updates on bugfixes and improvements on this dataset
+> **Idea:** Watch the [`transfermarkt-datasets` Github repository](https://github.com/dcaribou/transfermarkt-datasets) for updates on bugfixes and improvements on this dataset
 
 ### What is the status?
-This dataset is a work in progress. The best way to find out the status of the missing pieces is to check the `Issues` section on [player-scores](https://github.com/dcaribou/player-scores/issues). Some **current limitations** that you should probably be aware of are
-* Only a subset of all European domestic leagues are covered ([issue here](https://github.com/dcaribou/player-scores/issues/27))
-* The first season in the dataset is 2017-2018 ([issue here](https://github.com/dcaribou/player-scores/issues/12))
+This dataset is a work in progress. The best way to find out the status of the missing pieces is to check the `Issues` section on [transfermarkt-datasets](https://github.com/dcaribou/transfermarkt-datasets/issues). Some **current limitations** that you should probably be aware of are
+* Only a subset of all European domestic leagues are covered ([issue here](https://github.com/dcaribou/transfermarkt-datasets/issues/27))
+* The first season in the dataset is 2017-2018 ([issue here](https://github.com/dcaribou/transfermarkt-datasets/issues/12))
 
-> Bugfixes and enhancements contributing to this dataset are most welcome. If you want to contribute, the best way to start is by opening a new issue or picking an existing one from the [`Issues`](https://github.com/dcaribou/player-scores/issues) section in Github.
+> Bugfixes and enhancements contributing to this dataset are most welcome. If you want to contribute, the best way to start is by opening a new issue or picking an existing one from the [`Issues`](https://github.com/dcaribou/transfermarkt-datasets/issues) section in Github.


### PR DESCRIPTION
### pre-rename
- [x] Update all references to player-scores
  - [x] USER_AGENT
  - [x] Terraform resources
    - [x] Update references
    - [x] Renaming an S3 bucket requires manual operations as described [here](https://maheshkkolla.github.io/tech/2020/08/15/rename-s3-bucket-in-terraform.html)
      - [x] `aws s3 mb s3://transfermarkt-datasets`
      - [x] `aws s3 sync s3://player-scores s3://transfermarkt-datasets` 
  - [x]  `environment.yml`
  - [x] dvc remote storage
  - [x] Github action workflows
  - [x] Playbooks
  - [x] `datapackage_description.md`
  - [x] README.md
- [x] Improve documentation
  - [x] Remove initial section with the three phases of the broader scope project
  - [x] Change title in README
### post-rename
- [ ] Test references in README
- [ ] Test references in Kaggle and data.world
- [x] Change repo description
- [ ] `git remote set-url origin new_url`