### PR TITLE
Add new fields to `games` asset

### DIFF
--- a/3_sync.py
+++ b/3_sync.py
@@ -124,7 +124,7 @@ def publish_to_dataworld(folder):
     )
 
   metadata['summary'] = metadata['description']
-  metadata['description'] = metadata['title']
+  metadata['description'] = metadata['description']
   metadata['files'] = dw_files
   metadata['tags'] = metadata['keywords']
   metadata['license'] = metadata['licenses'][0]['CC0']

--- a/3_sync.py
+++ b/3_sync.py
@@ -109,7 +109,7 @@ def publish_to_dataworld(folder):
         'Bucket': 'transfermarkt-datasets',
         'Key': 'snapshots/data/prep/' + resource['path']
       },
-      ExpiresIn=50
+      ExpiresIn=120
     )
 
     dw_files.append(

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Scripts for transforming scraped `raw` data into a cleaned, validated [data pack
 $ python 2_prepare.py [--raw-files-location data/raw]
 ```
 For reference on the types of assets produced by this script checkout published datasets linked above.
-> :information_source: The preparation step uses `raw` data as input, hence raw files need to be available locally in order to run this step. You may pull raw assets by running `dvc pull` as mentioned earlier or by acquiring new and updated raw assets via `1_acquire.py` 
+
+The preparation step uses `raw` data as input, hence raw files need to be available locally in order to run this step. You may pull raw assets by running `dvc pull` as mentioned earlier or by acquiring new and updated raw assets via `1_acquire.py` 
 
 ### [infra](infra)
 Define all the necessary infrastructure for the project in the cloud with Terraform.

--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: f8151a922c19af7694a0256213c69710.dir
-  size: 79886162
+- md5: 07ee78016954a953d63d758485c16180.dir
+  size: 33800799
   nfiles: 6
   path: prep

--- a/data/raw.dvc
+++ b/data/raw.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 9495265ff1673bcfc448beb0ed2b09ab.dir
-  size: 1167709193
+- md5: 8a1ebf4c0dfa076a91c4acd5e65b3ec9.dir
+  size: 1164018520
   nfiles: 25
   path: raw

--- a/notebooks/prep_playbook.ipynb
+++ b/notebooks/prep_playbook.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -48,43 +48,43 @@
       "\n",
       "-> Processing games\n",
       "             season  home_club_goals  away_club_goals\n",
-      "count  19838.000000     19838.000000     19838.000000\n",
-      "mean    2017.979887         1.517139         1.198558\n",
-      "std        1.434616         1.304087         1.166721\n",
+      "count  19906.000000     19906.000000     19906.000000\n",
+      "mean    2017.987793         1.515674         1.199136\n",
+      "std        1.438761         1.303361         1.166833\n",
       "min     2015.000000         0.000000         0.000000\n",
       "25%     2017.000000         1.000000         0.000000\n",
       "50%     2018.000000         1.000000         1.000000\n",
       "75%     2019.000000         2.000000         2.000000\n",
-      "max     2020.000000        10.000000        13.000000\n",
+      "max     2021.000000        10.000000        13.000000\n",
       "All 0 validations passed!\n",
       "\n",
       "-> Processing clubs\n",
       "       total_market_value  squad_size  average_age  foreigners_number  \\\n",
-      "count          342.000000  351.000000   351.000000         342.000000   \n",
-      "mean            99.142719   26.837607    24.835897          11.956140   \n",
-      "std            168.803857    7.233996     4.285766           6.406637   \n",
+      "count          342.000000  351.000000   351.000000         351.000000   \n",
+      "mean            99.236404   26.860399    24.830769          11.686610   \n",
+      "std            168.758023    7.236842     4.285766           6.598166   \n",
       "min              1.260000    0.000000     0.000000           0.000000   \n",
-      "25%              9.050000   24.000000    24.500000           8.000000   \n",
-      "50%             24.030000   27.000000    25.400000          12.000000   \n",
+      "25%              9.395000   24.000000    24.500000           7.000000   \n",
+      "50%             24.290000   27.000000    25.400000          11.000000   \n",
       "75%            100.805000   31.000000    26.400000          16.000000   \n",
       "max            905.540000   53.000000    29.400000          37.000000   \n",
       "\n",
-      "       foreigners_percentage  national_team_players  \n",
-      "count             333.000000             351.000000  \n",
-      "mean               43.493093               5.276353  \n",
-      "std                18.282884               5.310419  \n",
-      "min                 3.300000               0.000000  \n",
-      "25%                31.000000               1.000000  \n",
-      "50%                42.900000               3.000000  \n",
-      "75%                56.300000               8.000000  \n",
-      "max               100.000000              23.000000  \n",
+      "       foreigners_percentage  national_team_players  stadium_seats  \n",
+      "count             333.000000             351.000000     351.000000  \n",
+      "mean               43.596096               5.296296   26383.683761  \n",
+      "std                18.193295               5.303687   18049.491510  \n",
+      "min                 3.300000               0.000000       0.000000  \n",
+      "25%                31.300000               1.000000   12325.000000  \n",
+      "50%                43.500000               3.000000   21577.000000  \n",
+      "75%                56.000000               8.000000   34807.500000  \n",
+      "max               100.000000              23.000000   99354.000000  \n",
       "All 1 validations passed!\n",
       "\n",
       "-> Processing players\n",
       "       height_in_cm\n",
-      "count  18686.000000\n",
-      "mean     171.186503\n",
-      "std       44.035479\n",
+      "count  18817.000000\n",
+      "mean     171.055216\n",
+      "std       44.303029\n",
       "min        0.000000\n",
       "25%      176.000000\n",
       "50%      182.000000\n",
@@ -94,9 +94,9 @@
       "\n",
       "-> Processing appearances\n",
       "               goals        assists  minutes_played   yellow_cards  \\\n",
-      "count  554520.000000  554520.000000   554520.000000  554520.000000   \n",
-      "mean        0.093896       0.071337       70.151396       0.150292   \n",
-      "std         0.326647       0.276330       29.470527       0.368635   \n",
+      "count  556563.000000  556563.000000   556563.000000  556563.000000   \n",
+      "mean        0.093842       0.071293       70.135613       0.150305   \n",
+      "std         0.326530       0.276233       29.477219       0.368640   \n",
       "min         0.000000       0.000000        0.000000       0.000000   \n",
       "25%         0.000000       0.000000       57.000000       0.000000   \n",
       "50%         0.000000       0.000000       90.000000       0.000000   \n",
@@ -104,9 +104,9 @@
       "max         5.000000       4.000000       90.000000       2.000000   \n",
       "\n",
       "           red_cards  \n",
-      "count  554520.000000  \n",
-      "mean        0.003607  \n",
-      "std         0.059948  \n",
+      "count  556563.000000  \n",
+      "mean        0.003597  \n",
+      "std         0.059868  \n",
       "min         0.000000  \n",
       "25%         0.000000  \n",
       "50%         0.000000  \n",
@@ -118,7 +118,7 @@
       "       league_id          name confederation\n",
       "count         14            14            14\n",
       "unique        14            13             1\n",
-      "top          GR1  premier-liga        europa\n",
+      "top          GB1  premier-liga        europa\n",
       "freq           1             2            14\n",
       "All 1 validations passed!\n",
       "\n"
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -161,7 +161,7 @@
       ]
      },
      "metadata": {},
-     "execution_count": 11
+     "execution_count": 34
     }
    ],
    "source": [
@@ -172,26 +172,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "error",
-     "ename": "AttributeError",
-     "evalue": "'GamesProcessor' object has no attribute 'raw_df'",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-12-91b90c7e11c9>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0mclubs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0masset\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'processor'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m \u001b[0mraw\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mclubs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraw_df\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0mprep\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mclubs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprep_df\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAttributeError\u001b[0m: 'GamesProcessor' object has no attribute 'raw_df'"
-     ]
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "             season  home_club_goals  away_club_goals\n",
+       "count  19906.000000     19906.000000     19906.000000\n",
+       "mean    2017.987793         1.515674         1.199136\n",
+       "std        1.438761         1.303361         1.166833\n",
+       "min     2015.000000         0.000000         0.000000\n",
+       "25%     2017.000000         1.000000         0.000000\n",
+       "50%     2018.000000         1.000000         1.000000\n",
+       "75%     2019.000000         2.000000         2.000000\n",
+       "max     2021.000000        10.000000        13.000000"
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>season</th>\n      <th>home_club_goals</th>\n      <th>away_club_goals</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>count</th>\n      <td>19906.000000</td>\n      <td>19906.000000</td>\n      <td>19906.000000</td>\n    </tr>\n    <tr>\n      <th>mean</th>\n      <td>2017.987793</td>\n      <td>1.515674</td>\n      <td>1.199136</td>\n    </tr>\n    <tr>\n      <th>std</th>\n      <td>1.438761</td>\n      <td>1.303361</td>\n      <td>1.166833</td>\n    </tr>\n    <tr>\n      <th>min</th>\n      <td>2015.000000</td>\n      <td>0.000000</td>\n      <td>0.000000</td>\n    </tr>\n    <tr>\n      <th>25%</th>\n      <td>2017.000000</td>\n      <td>1.000000</td>\n      <td>0.000000</td>\n    </tr>\n    <tr>\n      <th>50%</th>\n      <td>2018.000000</td>\n      <td>1.000000</td>\n      <td>1.000000</td>\n    </tr>\n    <tr>\n      <th>75%</th>\n      <td>2019.000000</td>\n      <td>2.000000</td>\n      <td>2.000000</td>\n    </tr>\n    <tr>\n      <th>max</th>\n      <td>2021.000000</td>\n      <td>10.000000</td>\n      <td>13.000000</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 35
     }
    ],
    "source": [
     "# get a reference to the pandas dataframes containing raw and prepared data\n",
     "clubs = asset['processor']\n",
     "\n",
-    "raw = clubs.raw_df\n",
+    "raw = clubs.raw_dfs\n",
     "prep = clubs.prep_df\n",
     "\n",
     "prep.describe()"

--- a/prep/assets/appearances.py
+++ b/prep/assets/appearances.py
@@ -53,7 +53,6 @@ class AppearancesProcessor(BaseProcessor):
       (json_normalized['second_yellow_cards'].str.len() > 0).astype('int32')
     )
     prep_df['red_cards'] = (json_normalized['red_cards'].str.len() > 0).astype('int32')
-    prep_df['url'] = 'https://www.transfermarkt.co.uk' + json_normalized['href']
 
     return prep_df
 
@@ -91,12 +90,6 @@ class AppearancesProcessor(BaseProcessor):
     self.schema.add_field(Field(name='minutes_played', type='integer'))
     self.schema.add_field(Field(name='yellow_cards', type='integer'))
     self.schema.add_field(Field(name='red_cards', type='integer'))
-    self.schema.add_field(Field(
-      name='url',
-      type='string',
-      format='uri'
-      )
-    )
     
     self.schema.primary_key = ['appearance_id']
     

--- a/prep/assets/games.py
+++ b/prep/assets/games.py
@@ -48,9 +48,14 @@ class GamesProcessor(BaseProcessor):
     prep_df['season'] = infer_season(json_normalized['date'])
     prep_df['round'] = json_normalized['matchday']
     prep_df['date'] = json_normalized['date']
+    prep_df['time'] = pandas.to_datetime(json_normalized['time']).dt.time 
     prep_df['home_club_id'] = home_club_href_parts[4]
     prep_df['away_club_id'] = away_club_href_parts[4]
     prep_df[['home_club_goals', 'away_club_goals']] = parse_aggregate(json_normalized['result'])
+    prep_df['home_club_position'] = json_normalized['home_club_position'].str.split(' ', 2, True)[2]
+    prep_df['away_club_position'] = json_normalized['away_club_position'].str.split(' ', 2, True)[2]
+    prep_df['stadium'] = json_normalized['stadium']
+    prep_df['attendance'] = json_normalized['attendance'].str.split(' ', 2, True)[1]
     prep_df['url'] = 'https://www.transfermarkt.co.uk' + json_normalized['href']
 
 
@@ -68,10 +73,15 @@ class GamesProcessor(BaseProcessor):
     self.schema.add_field(Field(name='season', type='integer'))
     self.schema.add_field(Field(name='round', type='string'))
     self.schema.add_field(Field(name='date', type='date'))
+    self.schema.add_field(Field(name='time', type='date'))
     self.schema.add_field(Field(name='home_club_id', type='integer'))
     self.schema.add_field(Field(name='away_club_id', type='integer'))
     self.schema.add_field(Field(name='home_club_goals', type='integer'))
     self.schema.add_field(Field(name='away_club_goals', type='integer'))
+    self.schema.add_field(Field(name='home_club_position', type='integer'))
+    self.schema.add_field(Field(name='away_club_position', type='integer'))
+    self.schema.add_field(Field(name='stadium', type='string'))
+    self.schema.add_field(Field(name='attendance', type='integer'))
     self.schema.add_field(Field(
         name='url',
         type='string',

--- a/prep/assets/games.py
+++ b/prep/assets/games.py
@@ -55,7 +55,10 @@ class GamesProcessor(BaseProcessor):
     prep_df['home_club_position'] = json_normalized['home_club_position'].str.split(' ', 2, True)[2]
     prep_df['away_club_position'] = json_normalized['away_club_position'].str.split(' ', 2, True)[2]
     prep_df['stadium'] = json_normalized['stadium']
-    prep_df['attendance'] = json_normalized['attendance'].str.split(' ', 2, True)[1]
+    prep_df['attendance'] = (
+      json_normalized['attendance'].str.split(' ', 2, True)[1]
+        .str.replace('.', '')
+    )
     prep_df['url'] = 'https://www.transfermarkt.co.uk' + json_normalized['href']
 
 
@@ -73,7 +76,7 @@ class GamesProcessor(BaseProcessor):
     self.schema.add_field(Field(name='season', type='integer'))
     self.schema.add_field(Field(name='round', type='string'))
     self.schema.add_field(Field(name='date', type='date'))
-    self.schema.add_field(Field(name='time', type='date'))
+    self.schema.add_field(Field(name='time', type='string'))
     self.schema.add_field(Field(name='home_club_id', type='integer'))
     self.schema.add_field(Field(name='away_club_id', type='integer'))
     self.schema.add_field(Field(name='home_club_goals', type='integer'))

--- a/prep/assets/games.py
+++ b/prep/assets/games.py
@@ -52,12 +52,12 @@ class GamesProcessor(BaseProcessor):
     prep_df['home_club_id'] = home_club_href_parts[4]
     prep_df['away_club_id'] = away_club_href_parts[4]
     prep_df[['home_club_goals', 'away_club_goals']] = parse_aggregate(json_normalized['result'])
-    prep_df['home_club_position'] = json_normalized['home_club_position'].str.split(' ', 2, True)[2]
-    prep_df['away_club_position'] = json_normalized['away_club_position'].str.split(' ', 2, True)[2]
+    prep_df['home_club_position'] = json_normalized['home_club_position'].str.split(' ', 2, True)[2].str.strip()
+    prep_df['away_club_position'] = json_normalized['away_club_position'].str.split(' ', 2, True)[2].str.strip()
     prep_df['stadium'] = json_normalized['stadium']
     prep_df['attendance'] = (
       json_normalized['attendance'].str.split(' ', 2, True)[1]
-        .str.replace('.', '')
+        .str.replace('.', '').str.strip()
     )
     prep_df['url'] = 'https://www.transfermarkt.co.uk' + json_normalized['href']
 

--- a/prep/datapackage_description.md
+++ b/prep/datapackage_description.md
@@ -1,8 +1,8 @@
 ### TL;DR
 > Clean, structured and **automatically updated** football data from [Transfermarkt](https://www.transfermarkt.co.uk/), including
 > * `20,000+` games from many seasons on all major national leagues and many others
-> * `350+` clubs from those leagues
-> * `19,000+` players from those clubs
+> * `300+` clubs from those leagues
+> * `18,000+` players from those clubs
 > * `500,000+` player appearance records from all games
 
 ### Why did we build it?


### PR DESCRIPTION
New fields added to `games` asset
* `time`
* `home_club_position` and `away_club_position`
* `attendance`
* `stadium`

Additionally, the `url` is removed from the appearances, as it's very repetitive and similar to the URL included in `players`.

- [x] Manually "merge" data files
  - Make a local copy of 'games' assets
  - DVC pull
  - Replace all but current seasons with local copy
  - Re run the pipeline + check
  - Commit and merge