### PR TITLE
Fix: keep last asset version on deduping

### DIFF
--- a/prep/assets/base.py
+++ b/prep/assets/base.py
@@ -54,7 +54,7 @@ class BaseProcessor:
 
   def process(self):
     self.prep_dfs = [self.process_segment(prep_df) for prep_df in self.raw_dfs]
-    self.prep_df = pandas.concat(self.prep_dfs, axis=0).drop_duplicates()
+    self.prep_df = pandas.concat(self.prep_dfs, axis=0).drop_duplicates(keep='last')
   
   def url_unquote(self, url_series):
     from urllib.parse import unquote

--- a/prep/assets/clubs.py
+++ b/prep/assets/clubs.py
@@ -58,7 +58,7 @@ class ClubsProcessor(BaseProcessor):
 
   def process(self):
     self.prep_dfs = [self.process_segment(prep_df) for prep_df in self.raw_dfs]
-    self.prep_df = pandas.concat(self.prep_dfs, axis=0).drop_duplicates(subset='club_id')
+    self.prep_df = pandas.concat(self.prep_dfs, axis=0).drop_duplicates(subset='club_id', keep='last')
 
   def get_validations(self):
     return [


### PR DESCRIPTION
Fixes #58 

Update deduping to keep last asset version across seasons. Prior to this change, the first version was kept in the prep assets.