### PR TITLE
Add referee and market value to datasets

### DIFF
--- a/2_prepare.py
+++ b/2_prepare.py
@@ -13,14 +13,16 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--raw-files-location', required=False, default='data/raw')
 parser.add_argument('--refresh-metadata', action='store_const', const=True, required=False, default=False)
 parser.add_argument('--run-validations', action='store_const', const=True, required=False, default=False)
+parser.add_argument('--season', required=False)
 
 args = parser.parse_args()
 
 raw_files_location = args.raw_files_location # ../data/raw
 refresh_metadata = args.refresh_metadata
 run_validations = args.run_validations
+season = args.season
 
-runner = AssetRunner(raw_files_location)
+runner = AssetRunner(raw_files_location, season)
 
 if refresh_metadata:
   # generate frictionless data package for prepared assets

--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: b35413193d05c31f11693eab10ad2c41.dir
-  size: 49106389
-  nfiles: 6
+- md5: c155aded803a6f5c1fd48874e646abdc.dir
+  size: 49931584
+  nfiles: 7
   path: prep

--- a/data/raw.dvc
+++ b/data/raw.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 04778119fd67339735a10f87d63ee153.dir
-  size: 1496685370
+- md5: 2f01ee7934ebef6e64693abcb4fa0162.dir
+  size: 1501535718
   nfiles: 28
   path: raw

--- a/prep/asset_runner.py
+++ b/prep/asset_runner.py
@@ -29,7 +29,7 @@ def get_assets(data_folder_path):
 
   return list(asset_keys.keys()) + ['competitions']
 class AssetRunner:
-  def __init__(self, data_folder_path='data/raw') -> None:
+  def __init__(self, data_folder_path='data/raw', season=None) -> None:
       self.data_folder_path = f"{data_folder_path}"
       self.prep_folder_path = 'prep/stage'
       self.datapackage_descriptor_path = f"{self.prep_folder_path}/dataset-metadata.json"
@@ -37,7 +37,10 @@ class AssetRunner:
       self.datapackage = None
       self.validation_report = None
 
-      seasons = get_seasons(self.data_folder_path)
+      if season is None:
+        seasons = get_seasons(self.data_folder_path)
+      else:
+        seasons = [season]
       assets = get_assets(self.data_folder_path)
       for asset in assets:
           class_name = asset.capitalize()

--- a/prep/assets/games.py
+++ b/prep/assets/games.py
@@ -61,6 +61,7 @@ class GamesProcessor(BaseProcessor):
       json_normalized['attendance'].str.split(' ', 2, True)[1]
         .str.replace('.', '', regex=False).str.strip()
     )
+    prep_df['referee'] = json_normalized['referee']
     prep_df['url'] = 'https://www.transfermarkt.co.uk' + json_normalized['href']
 
 
@@ -90,6 +91,7 @@ class GamesProcessor(BaseProcessor):
     self.schema.add_field(Field(name='away_club_position', type='integer'))
     self.schema.add_field(Field(name='stadium', type='string'))
     self.schema.add_field(Field(name='attendance', type='integer'))
+    self.schema.add_field(Field(name='referee', type='string'))
     self.schema.add_field(Field(
         name='url',
         type='string',

--- a/prep/assets/players.py
+++ b/prep/assets/players.py
@@ -5,6 +5,8 @@ from inflection import titleize
 import pandas
 import numpy
 
+import re
+
 from .base import BaseProcessor
 
 class PlayersProcessor(BaseProcessor):
@@ -75,6 +77,39 @@ class PlayersProcessor(BaseProcessor):
       ).fillna(0).astype(int)
     )
 
+    def parse_market_value(market_value):
+      """Parse a "market value" string into integer number representing GBP amounts (british pound)
+      such as "£240Th." or "£34.3m".
+
+      :param: market_value "Market value" string
+      :return: An integer number representing a GBP amount
+      """
+
+      if market_value is not None:
+        match = re.search('£([0-9\.]+)(Th|m)', market_value)
+        if match:
+          factor = match.group(2)
+          if factor == 'Th':
+            numeric_factor = 1000
+          elif factor == 'm':
+            numeric_factor = 1000000
+          else:
+            return None
+          
+          value = match.group(1)
+          return int(float(value)*numeric_factor)
+        else:
+          return None
+      else:
+        return None
+
+    prep_df['market_value_in_gbp'] = (
+      json_normalized['current_market_value'].apply(parse_market_value)
+    )
+    prep_df['highest_market_value_in_gbp'] = (
+      json_normalized['highest_market_value'].apply(parse_market_value)
+    )
+
     prep_df['url'] = self.url_prepend(json_normalized['href'])
 
     self.set_checkpoint('prep', prep_df)
@@ -104,6 +139,8 @@ class PlayersProcessor(BaseProcessor):
     self.schema.add_field(Field(name='sub_position', type='string'))
     self.schema.add_field(Field(name='foot', type='string'))
     self.schema.add_field(Field(name='height_in_cm', type='integer'))
+    self.schema.add_field(Field(name='market_value_in_gbp', type='integer'))
+    self.schema.add_field(Field(name='highest_market_value_in_gbp', type='integer'))
     self.schema.add_field(Field(
       name='url',
       type='string',

--- a/prep/assets/players.py
+++ b/prep/assets/players.py
@@ -78,10 +78,10 @@ class PlayersProcessor(BaseProcessor):
     )
 
     def parse_market_value(market_value):
-      """Parse a "market value" string into integer number representing GBP amounts (british pound)
+      """Parse a "market value" string into an integer number representing a GBP (british pounds) amount,
       such as "£240Th." or "£34.3m".
 
-      :param: market_value "Market value" string
+      :market_value: "Market value" string
       :return: An integer number representing a GBP amount
       """
 


### PR DESCRIPTION
* Add `referee` to `games`' asset (closes #57)
* Add `market_value_in_gbp` and `highest_market_value_in_gbp` to `players`' asset (contributed to the scraper [here](https://github.com/dcaribou/transfermarkt-scraper/pull/32), thanks @DonFloriano27)
* **Bonus**: Support a `--season` argument to the prep script for building assets using raw data from a single season