### PR TITLE
Add more resources to prep step

### DIFF
--- a/2_prepare.py
+++ b/2_prepare.py
@@ -59,7 +59,7 @@ def prepare_on_cloud(
       "--raw-files-location", "data/raw",
     ],
     vcpus=4,
-    memory=16384
+    memory=20480
   )
 
 # main

--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 0ec1c528bcfd0bc8bbcb00bdc5da99cb.dir
-  size: 61803323
+- md5: d1b4f7055d492737de37e8fb63ae5e0b.dir
+  size: 61826607
   nfiles: 7
   path: prep

--- a/infra/batch/batch.tf
+++ b/infra/batch/batch.tf
@@ -68,7 +68,7 @@ resource "aws_batch_job_definition" "job_definitions" {
   },
   "resourceRequirements": [
     {"type": "VCPU", "value": "4"},
-    {"type": "MEMORY", "value": "16384"}
+    {"type": "MEMORY", "value": "20480"}
   ],
   "executionRoleArn": "${var.execution_role_arn}",
   "jobRoleArn": "${var.execution_role_arn}",


### PR DESCRIPTION
Bumping max and current memory resources for prep step, as the current cap at 16GB is not enough.