### PR TITLE
Add radar-type comparator to manager perf analysis

### DIFF
--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 389066620f373bd5a5f12b035eb8e708.dir
-  size: 125712409
+- md5: 06a0e1572aba02af6ce804d9af7c06dc.dir
+  size: 125712931
   nfiles: 8
   path: prep

--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 31c18f934505ac9a34c71fa295acd247.dir
-  size: 125712931
+- md5: 1a94c8d21543d7ba1fe0c722711537ae.dir
+  size: 125711038
   nfiles: 8
   path: prep

--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 06a0e1572aba02af6ce804d9af7c06dc.dir
+- md5: 31c18f934505ac9a34c71fa295acd247.dir
   size: 125712931
   nfiles: 8
   path: prep

--- a/poetry.lock
+++ b/poetry.lock
@@ -3493,7 +3493,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.11, !=3.9.7"
-content-hash = "76deb32885d209cd34a46008587e2291199c628e8e492d65c7b92d6303b63395"
+content-hash = "86c8f3747822b07d0b271994921a9f401920bd44daa96599a4bab7b1bd22627b"
 
 [metadata.files]
 aiobotocore = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -2610,26 +2610,6 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
-name = "rdflib"
-version = "6.2.0"
-description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-isodate = "*"
-pyparsing = "*"
-
-[package.extras]
-berkeleydb = ["berkeleydb"]
-dev = ["black (==22.6.0)", "flake8", "isort", "mypy", "pep8-naming", "types-setuptools", "flakeheaven"]
-docs = ["myst-parser", "sphinx (<6)", "sphinxcontrib-apidoc", "sphinxcontrib-kroki", "sphinx-autodoc-typehints"]
-html = ["html5lib"]
-networkx = ["networkx"]
-tests = ["html5lib", "pytest", "pytest-cov"]
-
-[[package]]
 name = "requests"
 version = "2.28.1"
 description = "Python HTTP for Humans."
@@ -3017,19 +2997,6 @@ typing-extensions = ">=3.10.0.0"
 tzlocal = ">=1.1"
 validators = ">=0.2"
 watchdog = {version = "*", markers = "platform_system != \"Darwin\""}
-
-[[package]]
-name = "streamlit-agraph"
-version = "0.0.42"
-description = "Interactive Graph Vis for Streamlit."
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-networkx = ">=2.5"
-rdflib = ">=6.0.2"
-streamlit = ">=0.63"
 
 [[package]]
 name = "stringcase"
@@ -3493,7 +3460,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.11, !=3.9.7"
-content-hash = "76deb32885d209cd34a46008587e2291199c628e8e492d65c7b92d6303b63395"
+content-hash = "abcac3af162fc32c45f72361454bd1b204d7105b7fc1928f36224451f9ea1fa6"
 
 [metadata.files]
 aiobotocore = []
@@ -4081,7 +4048,6 @@ queuelib = [
     {file = "queuelib-1.6.2-py2.py3-none-any.whl", hash = "sha256:4b96d48f650a814c6fb2fd11b968f9c46178b683aad96d68f930fe13a8574d19"},
     {file = "queuelib-1.6.2.tar.gz", hash = "sha256:4b207267f2642a8699a1f806045c56eb7ad1a85a10c0e249884580d139c2fcd2"},
 ]
-rdflib = []
 requests = []
 requests-file = [
     {file = "requests-file-1.5.1.tar.gz", hash = "sha256:07d74208d3389d01c38ab89ef403af0cfec63957d53a0081d8eca738d0247d8e"},
@@ -4165,7 +4131,6 @@ sqlalchemy = []
 stack-data = []
 starlette = []
 streamlit = []
-streamlit-agraph = []
 stringcase = [
     {file = "stringcase-1.2.0.tar.gz", hash = "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -2153,6 +2153,17 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "plotly"
+version = "5.11.0"
+description = "An open-source, interactive data visualization library for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+tenacity = ">=6.2.0"
+
+[[package]]
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
@@ -3040,6 +3051,17 @@ python-versions = ">=3.7"
 widechars = ["wcwidth"]
 
 [[package]]
+name = "tenacity"
+version = "8.1.0"
+description = "Retry code until it succeeds"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+doc = ["reno", "sphinx", "tornado (>=4.5)"]
+
+[[package]]
 name = "terminado"
 version = "0.16.0"
 description = "Tornado websocket backend for the Xterm.js Javascript terminal emulator library."
@@ -3471,7 +3493,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.11, !=3.9.7"
-content-hash = "30e5feff17ea147de97cdad17fb72fd82479272f8437e30027f1ed6783a41bc4"
+content-hash = "76deb32885d209cd34a46008587e2291199c628e8e492d65c7b92d6303b63395"
 
 [metadata.files]
 aiobotocore = []
@@ -3883,6 +3905,7 @@ pickleshare = [
 ]
 pillow = []
 pkgutil-resolve-name = []
+plotly = []
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
@@ -4147,6 +4170,7 @@ stringcase = [
     {file = "stringcase-1.2.0.tar.gz", hash = "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008"},
 ]
 tabulate = []
+tenacity = []
 terminado = []
 text-unidecode = [
     {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -2975,11 +2975,11 @@ full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart", "pyyam
 
 [[package]]
 name = "streamlit"
-version = "1.12.0"
+version = "1.14.0"
 description = "The fastest way to build data apps in Python"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.7, !=3.9.7"
 
 [package.dependencies]
 altair = ">=3.2.0"
@@ -3470,8 +3470,8 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.8, <3.11"
-content-hash = "f205ab1e2dc45e158f41304ea3aedf931339953e3e2059219fc4c8a5470e639b"
+python-versions = ">=3.8, <3.11, !=3.9.7"
+content-hash = "30e5feff17ea147de97cdad17fb72fd82479272f8437e30027f1ed6783a41bc4"
 
 [metadata.files]
 aiobotocore = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -2610,6 +2610,26 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "rdflib"
+version = "6.2.0"
+description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+isodate = "*"
+pyparsing = "*"
+
+[package.extras]
+berkeleydb = ["berkeleydb"]
+dev = ["black (==22.6.0)", "flake8", "isort", "mypy", "pep8-naming", "types-setuptools", "flakeheaven"]
+docs = ["myst-parser", "sphinx (<6)", "sphinxcontrib-apidoc", "sphinxcontrib-kroki", "sphinx-autodoc-typehints"]
+html = ["html5lib"]
+networkx = ["networkx"]
+tests = ["html5lib", "pytest", "pytest-cov"]
+
+[[package]]
 name = "requests"
 version = "2.28.1"
 description = "Python HTTP for Humans."
@@ -2997,6 +3017,19 @@ typing-extensions = ">=3.10.0.0"
 tzlocal = ">=1.1"
 validators = ">=0.2"
 watchdog = {version = "*", markers = "platform_system != \"Darwin\""}
+
+[[package]]
+name = "streamlit-agraph"
+version = "0.0.42"
+description = "Interactive Graph Vis for Streamlit."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+networkx = ">=2.5"
+rdflib = ">=6.0.2"
+streamlit = ">=0.63"
 
 [[package]]
 name = "stringcase"
@@ -3460,7 +3493,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.11, !=3.9.7"
-content-hash = "abcac3af162fc32c45f72361454bd1b204d7105b7fc1928f36224451f9ea1fa6"
+content-hash = "76deb32885d209cd34a46008587e2291199c628e8e492d65c7b92d6303b63395"
 
 [metadata.files]
 aiobotocore = []
@@ -4048,6 +4081,7 @@ queuelib = [
     {file = "queuelib-1.6.2-py2.py3-none-any.whl", hash = "sha256:4b96d48f650a814c6fb2fd11b968f9c46178b683aad96d68f930fe13a8574d19"},
     {file = "queuelib-1.6.2.tar.gz", hash = "sha256:4b207267f2642a8699a1f806045c56eb7ad1a85a10c0e249884580d139c2fcd2"},
 ]
+rdflib = []
 requests = []
 requests-file = [
     {file = "requests-file-1.5.1.tar.gz", hash = "sha256:07d74208d3389d01c38ab89ef403af0cfec63957d53a0081d8eca738d0247d8e"},
@@ -4131,6 +4165,7 @@ sqlalchemy = []
 stack-data = []
 starlette = []
 streamlit = []
+streamlit-agraph = []
 stringcase = [
     {file = "stringcase-1.2.0.tar.gz", hash = "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -786,7 +786,7 @@ pgp = ["gpg"]
 
 [[package]]
 name = "dvc"
-version = "2.30.0"
+version = "2.33.1"
 description = "Git for data scientists - manage your code and data together"
 category = "main"
 optional = false
@@ -798,11 +798,11 @@ colorama = ">=0.3.9"
 configobj = ">=5.0.6"
 distro = ">=1.3.0"
 dpath = ">=2.0.2,<3"
-dvc-data = "0.17.1"
+dvc-data = "0.25.2"
 dvc-http = "2.27.2"
 dvc-render = "0.0.12"
 dvc-s3 = {version = "2.20.1", optional = true, markers = "extra == \"s3\""}
-dvc-task = "0.1.3"
+dvc-task = "0.1.4"
 dvclive = ">=0.10.0"
 flatten-dict = ">=0.4.1,<1"
 "flufl.lock" = ">=5"
@@ -821,7 +821,7 @@ pyparsing = ">=2.4.7"
 requests = ">=2.22.0"
 rich = ">=10.13.0"
 "ruamel.yaml" = ">=0.17.11"
-scmrepo = "0.1.1"
+scmrepo = "0.1.2"
 shortuuid = ">=0.5.0"
 shtab = ">=1.3.4,<2"
 tabulate = ">=0.8.7"
@@ -832,26 +832,26 @@ voluptuous = ">=0.11.7"
 "zc.lockfile" = ">=1.2.1"
 
 [package.extras]
-all = ["dvc-azure (==2.20.4)", "dvc-gdrive (==2.19.0)", "dvc-gs (==2.19.1)", "dvc-oss (==2.19.0)", "dvc-s3 (==2.20.1)", "dvc-ssh (==2.19.0)", "dvc-webdav (==2.19.0)", "dvc-webhdfs (==2.19.0)", "dvc-hdfs (==2.19.0)"]
+all = ["dvc-azure (==2.20.4)", "dvc-gdrive (==2.19.0)", "dvc-gs (==2.19.1)", "dvc-oss (==2.19.0)", "dvc-s3 (==2.20.1)", "dvc-ssh (==2.20.0)", "dvc-webdav (==2.19.0)", "dvc-webhdfs (==2.19.0)", "dvc-hdfs (==2.19.0)"]
 azure = ["dvc-azure (==2.20.4)"]
-dev = ["dvc-azure (==2.20.4)", "dvc-gdrive (==2.19.0)", "dvc-gs (==2.19.1)", "dvc-oss (==2.19.0)", "dvc-s3 (==2.20.1)", "dvc-ssh (==2.19.0)", "dvc-webdav (==2.19.0)", "dvc-webhdfs (==2.19.0)", "tpi[ssh] (>=2.1.0)", "pytest (==7.1.3)", "pytest-cov (==4.0.0)", "pytest-xdist (==2.5.0)", "pytest-mock (==3.9.0)", "pytest-lazy-fixture (==0.6.3)", "pytest-test-utils (==0.0.8)", "flaky (==3.7.0)", "pytest-timeout (==2.1.0)", "filelock (==3.8.0)", "pylint (==2.15.2)", "pylint-pytest (==1.1.2)", "astroid (==2.12.9)", "pylint-plugin-utils (==0.7)", "mypy (==0.982)", "types-requests (>=2.27.15)", "types-tabulate (>=0.8.6)", "types-toml (>=0.10.4)", "dvclive[image] (>=0.7.3)", "beautifulsoup4 (==4.11.1)", "dvc-data", "pytest-docker (==0.11.0)", "dvc-hdfs (==2.19.0)", "pywin32 (>=225)"]
+dev = ["dvc-azure (==2.20.4)", "dvc-gdrive (==2.19.0)", "dvc-gs (==2.19.1)", "dvc-oss (==2.19.0)", "dvc-s3 (==2.20.1)", "dvc-ssh (==2.20.0)", "dvc-webdav (==2.19.0)", "dvc-webhdfs (==2.19.0)", "tpi[ssh] (>=2.1.0)", "pytest (==7.1.3)", "pytest-cov (==4.0.0)", "pytest-xdist (==2.5.0)", "pytest-mock (==3.10.0)", "pytest-lazy-fixture (==0.6.3)", "pytest-test-utils (==0.0.8)", "flaky (==3.7.0)", "pytest-timeout (==2.1.0)", "filelock (==3.8.0)", "pylint (==2.15.4)", "pylint-pytest (==1.1.2)", "pylint-plugin-utils (==0.7)", "mypy (==0.982)", "types-requests (>=2.27.15)", "types-tabulate (>=0.8.6)", "types-toml (>=0.10.4)", "dvclive[image] (>=0.7.3)", "beautifulsoup4 (==4.11.1)", "dvc-data", "pytest-docker (==0.11.0)", "dvc-hdfs (==2.19.0)", "pywin32 (>=225)"]
 gdrive = ["dvc-gdrive (==2.19.0)"]
 gs = ["dvc-gs (==2.19.1)"]
 hdfs = ["dvc-hdfs (==2.19.0)"]
 oss = ["dvc-oss (==2.19.0)"]
 s3 = ["dvc-s3 (==2.20.1)"]
-ssh = ["dvc-ssh (==2.19.0)"]
-ssh_gssapi = ["dvc-ssh[gssapi] (==2.19.0)"]
+ssh = ["dvc-ssh (==2.20.0)"]
+ssh_gssapi = ["dvc-ssh[gssapi] (==2.20.0)"]
 terraform = ["tpi[ssh] (>=2.1.0)"]
 testing = ["pytest-test-utils (==0.0.8)"]
-tests = ["tpi[ssh] (>=2.1.0)", "dvc-ssh (==2.19.0)", "pytest (==7.1.3)", "pytest-cov (==4.0.0)", "pytest-xdist (==2.5.0)", "pytest-mock (==3.9.0)", "pytest-lazy-fixture (==0.6.3)", "pytest-test-utils (==0.0.8)", "flaky (==3.7.0)", "pytest-timeout (==2.1.0)", "filelock (==3.8.0)", "pylint (==2.15.2)", "pylint-pytest (==1.1.2)", "astroid (==2.12.9)", "pylint-plugin-utils (==0.7)", "mypy (==0.982)", "types-requests (>=2.27.15)", "types-tabulate (>=0.8.6)", "types-toml (>=0.10.4)", "dvclive[image] (>=0.7.3)", "beautifulsoup4 (==4.11.1)", "pytest-docker (==0.11.0)", "pywin32 (>=225)"]
+tests = ["tpi[ssh] (>=2.1.0)", "dvc-ssh (==2.20.0)", "pytest (==7.1.3)", "pytest-cov (==4.0.0)", "pytest-xdist (==2.5.0)", "pytest-mock (==3.10.0)", "pytest-lazy-fixture (==0.6.3)", "pytest-test-utils (==0.0.8)", "flaky (==3.7.0)", "pytest-timeout (==2.1.0)", "filelock (==3.8.0)", "pylint (==2.15.4)", "pylint-pytest (==1.1.2)", "pylint-plugin-utils (==0.7)", "mypy (==0.982)", "types-requests (>=2.27.15)", "types-tabulate (>=0.8.6)", "types-toml (>=0.10.4)", "dvclive[image] (>=0.7.3)", "beautifulsoup4 (==4.11.1)", "pytest-docker (==0.11.0)", "pywin32 (>=225)"]
 webdav = ["dvc-webdav (==2.19.0)"]
 webhdfs = ["dvc-webhdfs (==2.19.0)"]
 webhdfs_kerberos = ["dvc-webhdfs[kerberos] (==2.19.0)"]
 
 [[package]]
 name = "dvc-data"
-version = "0.17.1"
+version = "0.25.2"
 description = "dvc data"
 category = "main"
 optional = false
@@ -861,7 +861,7 @@ python-versions = ">=3.8"
 attrs = ">=21.3.0"
 dictdiffer = ">=0.8.1"
 diskcache = ">=5.2.1"
-dvc-objects = "0.7.0"
+dvc-objects = "0.12.2"
 funcy = ">=1.14"
 nanotime = ">=0.5.2"
 pygtrie = ">=2.3.2"
@@ -891,22 +891,22 @@ tests = ["wheel (==0.37.0)", "dvc", "pytest (==6.2.5)", "pytest-cov (==3.0.0)", 
 
 [[package]]
 name = "dvc-objects"
-version = "0.7.0"
+version = "0.12.2"
 description = "dvc objects"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 
 [package.dependencies]
-fsspec = ">=2021.10.1"
+fsspec = ">=2022.10.0"
 funcy = ">=1.14"
 shortuuid = ">=0.5.0"
 tqdm = ">=4.63.1,<5"
 typing-extensions = ">=3.7.4"
 
 [package.extras]
-tests = ["pytest-servers (==0.0.10)", "mypy (==0.971)", "pylint (==2.15.0)", "pytest-mock (==3.8.2)", "pytest-cov (==3.0.0)", "pytest-sugar (==0.9.5)", "pytest (==7.1.2)"]
-dev = ["pytest-servers (==0.0.10)", "mypy (==0.971)", "pylint (==2.15.0)", "pytest-mock (==3.8.2)", "pytest-cov (==3.0.0)", "pytest-sugar (==0.9.5)", "pytest (==7.1.2)"]
+dev = ["pytest (==7.1.2)", "pytest-sugar (==0.9.5)", "pytest-cov (==3.0.0)", "pytest-mock (==3.8.2)", "pylint (==2.15.0)", "mypy (==0.971)", "pytest-servers (==0.0.10)"]
+tests = ["pytest (==7.1.2)", "pytest-sugar (==0.9.5)", "pytest-cov (==3.0.0)", "pytest-mock (==3.8.2)", "pylint (==2.15.0)", "mypy (==0.971)", "pytest-servers (==0.0.10)"]
 
 [[package]]
 name = "dvc-render"
@@ -945,7 +945,7 @@ tests = ["wheel (==0.37.0)", "dvc", "pytest (==6.2.5)", "pytest-cov (==3.0.0)", 
 
 [[package]]
 name = "dvc-task"
-version = "0.1.3"
+version = "0.1.4"
 description = "Extensible task queue used in DVC."
 category = "main"
 optional = false
@@ -959,9 +959,9 @@ pywin32 = {version = ">=225", markers = "sys_platform == \"win32\""}
 shortuuid = ">=1.0.8"
 
 [package.extras]
-tests = ["celery-types (>=0.11.0)", "pytest-celery", "pytest-test-utils (>=0.0.6)", "flaky (==3.7.0)", "mypy (==0.971)", "pylint (==2.14.5)", "pytest-mock (==3.8.2)", "pytest-cov (==3.0.0)", "pytest-sugar (==0.9.5)", "pytest (==7.1.2)"]
-docs = ["mkdocstrings-python (==0.7.1)", "mkdocs-section-index (==0.3.4)", "mkdocs-material (==8.4.1)", "mkdocs-gen-files (==0.3.5)", "mkdocs (==1.3.1)"]
-dev = ["mkdocstrings-python (==0.7.1)", "mkdocs-section-index (==0.3.4)", "mkdocs-material (==8.4.1)", "mkdocs-gen-files (==0.3.5)", "mkdocs (==1.3.1)", "celery-types (>=0.11.0)", "pytest-celery", "pytest-test-utils (>=0.0.6)", "flaky (==3.7.0)", "mypy (==0.971)", "pylint (==2.14.5)", "pytest-mock (==3.8.2)", "pytest-cov (==3.0.0)", "pytest-sugar (==0.9.5)", "pytest (==7.1.2)"]
+dev = ["pytest (==7.1.2)", "pytest-sugar (==0.9.5)", "pytest-cov (==3.0.0)", "pytest-mock (==3.8.2)", "pylint (==2.14.5)", "mypy (==0.971)", "flaky (==3.7.0)", "pytest-test-utils (>=0.0.6)", "pytest-celery", "celery-types (>=0.11.0)", "mkdocs (==1.3.1)", "mkdocs-gen-files (==0.3.5)", "mkdocs-material (==8.4.1)", "mkdocs-section-index (==0.3.4)", "mkdocstrings-python (==0.7.1)"]
+docs = ["mkdocs (==1.3.1)", "mkdocs-gen-files (==0.3.5)", "mkdocs-material (==8.4.1)", "mkdocs-section-index (==0.3.4)", "mkdocstrings-python (==0.7.1)"]
+tests = ["pytest (==7.1.2)", "pytest-sugar (==0.9.5)", "pytest-cov (==3.0.0)", "pytest-mock (==3.8.2)", "pylint (==2.14.5)", "mypy (==0.971)", "flaky (==3.7.0)", "pytest-test-utils (>=0.0.6)", "pytest-celery", "celery-types (>=0.11.0)"]
 
 [[package]]
 name = "dvclive"
@@ -1107,7 +1107,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "fsspec"
-version = "2022.8.2"
+version = "2022.10.0"
 description = "File-system specification"
 category = "main"
 optional = false
@@ -2599,6 +2599,26 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "rdflib"
+version = "6.2.0"
+description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+isodate = "*"
+pyparsing = "*"
+
+[package.extras]
+berkeleydb = ["berkeleydb"]
+dev = ["black (==22.6.0)", "flake8", "isort", "mypy", "pep8-naming", "types-setuptools", "flakeheaven"]
+docs = ["myst-parser", "sphinx (<6)", "sphinxcontrib-apidoc", "sphinxcontrib-kroki", "sphinx-autodoc-typehints"]
+html = ["html5lib"]
+networkx = ["networkx"]
+tests = ["html5lib", "pytest", "pytest-cov"]
+
+[[package]]
 name = "requests"
 version = "2.28.1"
 description = "Python HTTP for Humans."
@@ -2688,7 +2708,7 @@ python-versions = "*"
 
 [[package]]
 name = "s3fs"
-version = "2022.8.2"
+version = "2022.10.0"
 description = "Convenient Filesystem interface over S3"
 category = "main"
 optional = false
@@ -2697,7 +2717,7 @@ python-versions = ">= 3.7"
 [package.dependencies]
 aiobotocore = ">=2.4.0,<2.5.0"
 aiohttp = "<4.0.0a0 || >4.0.0a0,<4.0.0a1 || >4.0.0a1"
-fsspec = "2022.8.2"
+fsspec = "2022.10.0"
 
 [package.extras]
 awscli = ["aiobotocore[awscli] (>=2.4.0,<2.5.0)"]
@@ -2735,7 +2755,7 @@ dev = ["mypy", "typing-extensions", "pycodestyle", "flake8"]
 
 [[package]]
 name = "scmrepo"
-version = "0.1.1"
+version = "0.1.2"
 description = "SCM wrapper and fsspec filesystem for Git for use in DVC"
 category = "main"
 optional = false
@@ -2752,8 +2772,8 @@ pygit2 = ">=1.10.0"
 pygtrie = ">=2.3.2"
 
 [package.extras]
-tests = ["pytest-docker (==0.12.0)", "types-paramiko (==2.11.3)", "types-mock (==4.0.15)", "types-certifi (==2021.10.8.3)", "paramiko (==2.11.0)", "mock (==4.0.3)", "pytest-asyncio (==0.18.3)", "pytest-test-utils (==0.0.8)", "mypy (==0.971)", "pylint (==2.15.0)", "pytest-mock (==3.8.2)", "pytest-cov (==3.0.0)", "pytest-sugar (==0.9.5)", "pytest (==7.1.2)"]
-dev = ["pytest-docker (==0.12.0)", "types-paramiko (==2.11.3)", "types-mock (==4.0.15)", "types-certifi (==2021.10.8.3)", "paramiko (==2.11.0)", "mock (==4.0.3)", "pytest-asyncio (==0.18.3)", "pytest-test-utils (==0.0.8)", "mypy (==0.971)", "pylint (==2.15.0)", "pytest-mock (==3.8.2)", "pytest-cov (==3.0.0)", "pytest-sugar (==0.9.5)", "pytest (==7.1.2)"]
+dev = ["pytest (==7.1.2)", "pytest-sugar (==0.9.5)", "pytest-cov (==3.0.0)", "pytest-mock (==3.8.2)", "pylint (==2.15.0)", "mypy (==0.971)", "pytest-test-utils (==0.0.8)", "pytest-asyncio (==0.18.3)", "mock (==4.0.3)", "paramiko (==2.11.0)", "types-certifi (==2021.10.8.3)", "types-mock (==4.0.15)", "types-paramiko (==2.11.6)", "pytest-docker (==0.12.0)"]
+tests = ["pytest (==7.1.2)", "pytest-sugar (==0.9.5)", "pytest-cov (==3.0.0)", "pytest-mock (==3.8.2)", "pylint (==2.15.0)", "mypy (==0.971)", "pytest-test-utils (==0.0.8)", "pytest-asyncio (==0.18.3)", "mock (==4.0.3)", "paramiko (==2.11.0)", "types-certifi (==2021.10.8.3)", "types-mock (==4.0.15)", "types-paramiko (==2.11.6)", "pytest-docker (==0.12.0)"]
 
 [[package]]
 name = "scrapy"
@@ -2986,6 +3006,19 @@ typing-extensions = ">=3.10.0.0"
 tzlocal = ">=1.1"
 validators = ">=0.2"
 watchdog = {version = "*", markers = "platform_system != \"Darwin\""}
+
+[[package]]
+name = "streamlit-agraph"
+version = "0.0.42"
+description = "Interactive Graph Vis for Streamlit."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+networkx = ">=2.5"
+rdflib = ">=6.0.2"
+streamlit = ">=0.63"
 
 [[package]]
 name = "stringcase"
@@ -3254,7 +3287,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uvicorn"
-version = "0.18.3"
+version = "0.19.0"
 description = "The lightning-fast ASGI server."
 category = "dev"
 optional = false
@@ -3264,7 +3297,7 @@ python-versions = ">=3.7"
 click = ">=7.0"
 colorama = {version = ">=0.4", optional = true, markers = "sys_platform == \"win32\" and extra == \"standard\""}
 h11 = ">=0.8"
-httptools = {version = ">=0.4.0", optional = true, markers = "extra == \"standard\""}
+httptools = {version = ">=0.5.0", optional = true, markers = "extra == \"standard\""}
 python-dotenv = {version = ">=0.13", optional = true, markers = "extra == \"standard\""}
 pyyaml = {version = ">=5.1", optional = true, markers = "extra == \"standard\""}
 uvloop = {version = ">=0.14.0,<0.15.0 || >0.15.0,<0.15.1 || >0.15.1", optional = true, markers = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\" and extra == \"standard\""}
@@ -3272,7 +3305,7 @@ watchfiles = {version = ">=0.13", optional = true, markers = "extra == \"standar
 websockets = {version = ">=10.0", optional = true, markers = "extra == \"standard\""}
 
 [package.extras]
-standard = ["colorama (>=0.4)", "httptools (>=0.4.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.0)"]
+standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.0)"]
 
 [[package]]
 name = "uvloop"
@@ -3438,7 +3471,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.11"
-content-hash = "e9a28a12ed18a03ee6c4c56eac15d5a58f8121f1441d207ac6b169065f1ed7f6"
+content-hash = "f205ab1e2dc45e158f41304ea3aedf931339953e3e2059219fc4c8a5470e639b"
 
 [metadata.files]
 aiobotocore = []
@@ -4025,6 +4058,7 @@ queuelib = [
     {file = "queuelib-1.6.2-py2.py3-none-any.whl", hash = "sha256:4b96d48f650a814c6fb2fd11b968f9c46178b683aad96d68f930fe13a8574d19"},
     {file = "queuelib-1.6.2.tar.gz", hash = "sha256:4b207267f2642a8699a1f806045c56eb7ad1a85a10c0e249884580d139c2fcd2"},
 ]
+rdflib = []
 requests = []
 requests-file = [
     {file = "requests-file-1.5.1.tar.gz", hash = "sha256:07d74208d3389d01c38ab89ef403af0cfec63957d53a0081d8eca738d0247d8e"},
@@ -4108,6 +4142,7 @@ sqlalchemy = []
 stack-data = []
 starlette = []
 streamlit = []
+streamlit-agraph = []
 stringcase = [
     {file = "stringcase-1.2.0.tar.gz", hash = "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ Scrapy = "^2.6.2"
 streamlit = "1.14.0"
 geopy = "^2.2.0"
 plotly = "^5.11.0"
+streamlit-agraph = "^0.0.42"
 
 [tool.poetry.dev-dependencies]
 jupyter = "^1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ kaggle = "^1.5.12"
 Scrapy = "^2.6.2"
 streamlit = "^1.11.1"
 geopy = "^2.2.0"
+streamlit-agraph = "^0.0.42"
 
 [tool.poetry.dev-dependencies]
 jupyter = "^1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Extract, prepare, publish and update Transfermarkt datasets."
 authors = ["dcaribou <davidcereijo@live.com>"]
 
 [tool.poetry.dependencies]
-python = ">=3.8, <3.11"
+python = ">=3.8, <3.11, !=3.9.7"
 frictionless = "^4.31.0"
 pandas = "^1.4.2"
 boto3 = "^1.0.4"
@@ -17,7 +17,7 @@ dvc = {extras = ["s3"], version = "^2.17.0"}
 scipy = "^1.8.0"
 kaggle = "^1.5.12"
 Scrapy = "^2.6.2"
-streamlit = "^1.11.1"
+streamlit = "1.14.0"
 geopy = "^2.2.0"
 streamlit-agraph = "^0.0.42"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ Scrapy = "^2.6.2"
 streamlit = "1.14.0"
 geopy = "^2.2.0"
 streamlit-agraph = "^0.0.42"
+plotly = "^5.11.0"
 
 [tool.poetry.dev-dependencies]
 jupyter = "^1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ kaggle = "^1.5.12"
 Scrapy = "^2.6.2"
 streamlit = "1.14.0"
 geopy = "^2.2.0"
-streamlit-agraph = "^0.0.42"
 plotly = "^5.11.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["dcaribou <davidcereijo@live.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.8, <3.11, !=3.9.7"
-frictionless = "^4.31.0"
+frictionless = "4.40.8"
 pandas = "^1.4.2"
 boto3 = "^1.0.4"
 inflection = "^0.5.1"

--- a/streamlit/markdown_blocks/analysis/analysis_manager_performance.md
+++ b/streamlit/markdown_blocks/analysis/analysis_manager_performance.md
@@ -1,5 +1,3 @@
-Analysis on manager performance.
-
 This analysis amis to show which managers exhibit the best performance in their careers. The peformance indicator in this case is the win percentage (`pct_win`).
 
 The win percentage is calculated looking at the team performance, mostly based on the `club_games` asset, and it's displayed across seasons and competition types (domestic or international).

--- a/streamlit/pages/02_🔎_explore.py
+++ b/streamlit/pages/02_🔎_explore.py
@@ -1,23 +1,27 @@
 import streamlit as st
 import pandas as pd
 
-from utils import read_file_contents, load_td, draw_asset
-from inflection import dasherize
+from utils import (
+    read_file_contents,
+    load_td,
+    draw_asset,
+    draw_dataset_er_diagram
+)
 
 td = load_td()
 
 st.title("Explore :mag_right:")
-st.markdown("""
-> :warning: There is no support yet for downloading assets from the streamlit app.
-> For downloading the data, use the [data.world](https://data.world/dcereijo/player-scores) or [Kaggle](https://www.kaggle.com/datasets/davidcariboo/player-scores) datasets for now.
 
------
-"""
-)
-st.image("resources/diagram.svg", use_column_width=True)
+draw_dataset_er_diagram(td)
+
 st.markdown(
     read_file_contents("streamlit/markdown_blocks/explore/intro.md")
 )
+
+st.info("""
+There is no support yet for downloading assets from the streamlit app.
+For downloading the data, use the data.world or Kaggle datasets for now.""", 
+icon="ℹ️")
 
 st.markdown("""
 -----

--- a/streamlit/pages/02_🔎_explore.py
+++ b/streamlit/pages/02_🔎_explore.py
@@ -20,7 +20,10 @@ st.markdown(
 
 st.info("""
 There is no support yet for downloading assets from the streamlit app.
-For downloading the data, use the data.world or Kaggle datasets for now.""", 
+For downloading the data, may use the equivalent [data.world](https://data.world/dcereijo/player-scores) 
+or [Kaggle](https://www.kaggle.com/datasets/davidcariboo/player-scores) 
+datasets for now.
+""", 
 icon="ℹ️")
 
 st.markdown("""

--- a/streamlit/pages/02_🔎_explore.py
+++ b/streamlit/pages/02_🔎_explore.py
@@ -12,7 +12,8 @@ td = load_td()
 
 st.title("Explore :mag_right:")
 
-draw_dataset_er_diagram(td)
+# i'm not convinced by this
+# draw_dataset_er_diagram(td)
 
 st.markdown(
     read_file_contents("streamlit/markdown_blocks/explore/intro.md")

--- a/streamlit/pages/04_📈_analysis:_manager_performance.py
+++ b/streamlit/pages/04_📈_analysis:_manager_performance.py
@@ -1,10 +1,12 @@
 from altair.vegalite.v4.api import value
 import streamlit as st
 import pandas as pd
+from traitlets import default
 
 from utils import read_file_contents, load_td
 
 import altair as alt
+import plotly.express as px
 
 td = load_td()
 
@@ -21,25 +23,50 @@ st.markdown("""
 
 competitions = td.assets["cur_competitions"].prep_df
 club_games = td.assets["cur_club_games"].prep_df
-games = td.assets["cur_games"].prep_df
+games = td.assets["cur_games"].prep_df.copy()
 clubs = td.assets["cur_clubs"].prep_df
+
+# TODO: it's kind of annoying that this does not come in with the correct type already
+games["season"] = pd.to_datetime(games["season"], format="%Y")
 
 # define the set of leagues to be used in the analysis
 
-st.subheader("Filters")
+DEFAULT_COMPETITIONS = ["GB1", "L1", "ES1", "IT1"]
+DEFAULT_SEASONS = [2021, 2022]
+DEFAULT_MANAGERS = ["Jürgen Klopp", "Pep Guardiola"]
+DEFAULT_COMPETITION_TYPES = [
+    "domestic_cup", "domestic_league", "international_cup"
+]
 
-col1, col2 = st.columns(2)
+with st.expander("Baseline Filters"):
 
-focus_on_leagues = col1.multiselect(
-    "Competition codes to be included",
-    options=competitions["competition_id"].unique(),
-    default=["GB1", "L1", "ES1", "IT1"]
-)
+    col1, col2 = st.columns(2)
 
-minimun_number_of_games_played = (
-    col2.number_input('Minimum number of games played in a season', value=5)
-)
-top_n = col2.number_input("Top N performers", value=20)
+    competition_ids = col1.multiselect(
+        "Domestic competition IDs",
+        options=competitions["competition_id"].unique(),
+        default=DEFAULT_COMPETITIONS
+    )
+
+    all_seasons = games["season"].dt.year.unique()
+    seasons_limits = col2.slider(
+        label="Seasons",
+        min_value=int(min(all_seasons)),
+        max_value=int(max(all_seasons)),
+        step=1,
+        value=DEFAULT_SEASONS
+    )
+    seasons = list(range(seasons_limits[0], seasons_limits[1], 1))
+
+    managers = col1.multiselect(
+        label="Managers",
+        options=club_games["own_manager_name"].unique(),
+        default=DEFAULT_MANAGERS
+    )
+
+    minimun_number_of_games_played = (
+        col2.number_input('Minimum number of games played in a season', value=5)
+    )
 
 # create a data mart with all required measures and dimensions
 # for the base mart we use a "club game" granularity
@@ -59,84 +86,95 @@ mart = club_games.merge(
         on="club_id"
     )
 
-# TODO: it's kind of annoying that this does not come in with the correct type already
-mart["season"] = pd.to_datetime(mart["season"], format="%Y")
-
-# limit the analysis to the selected set of competitions only
-mart = mart[mart["club_domestic_competition_id"].isin(focus_on_leagues)]
+baselined_mart = mart[
+    (mart["season"].dt.year.isin(seasons)) &
+    (mart["club_domestic_competition_id"].isin(competition_ids)) & 
+    (mart["own_manager_name"].isin(managers)) &
+    (mart["competition_type"].isin(DEFAULT_COMPETITION_TYPES))
+]
 
 # manager perfomance is evaluated on its win percentage
 # we want to calculate manages win percentage by season and competition type
 
 managers_win_pct_per_season = (
-    mart
+    baselined_mart
         .groupby(by=[
                 "club_pretty_name", "season", "own_manager_name", "competition_type"
             ])["is_win"]
         .agg(func=["count", "sum"])
         .reset_index()
 )
-managers_win_pct_per_season.rename(columns={"count": "total_games"}, inplace=True)
-managers_win_pct_per_season["pct_win"] = managers_win_pct_per_season["sum"] / managers_win_pct_per_season["total_games"]
-del managers_win_pct_per_season["sum"]
+managers_win_pct_per_season.rename(
+    columns={
+        "count": "total_games",
+        "sum": "total_wins",
+    },
+    inplace=True
+)
+managers_win_pct_per_season["pct_win"] = (
+    managers_win_pct_per_season["total_wins"] / managers_win_pct_per_season["total_games"]
+)
 
 # now we only want to consider managers who had a significative number of games during a season
 
 managers_win_pct_per_season = managers_win_pct_per_season[
-    managers_win_pct_per_season["total_games"] > minimun_number_of_games_played
+    (managers_win_pct_per_season["total_games"] > minimun_number_of_games_played)
 ]
 
-# we want to further focus the analysis on a small set of high performance managers
-top_n_managers = managers_win_pct_per_season.nlargest(n=top_n, columns=["pct_win"])[
-    "own_manager_name"
-].values
+# the comparative view allows visualizing manager win percentage by competition side by side
 
-managers_win_pct_per_season = managers_win_pct_per_season[
-    managers_win_pct_per_season["own_manager_name"].isin(top_n_managers)]
+managers_win_pct_comparative = (
+    managers_win_pct_per_season[
+        managers_win_pct_per_season["season"].dt.year.isin(seasons) &
+        managers_win_pct_per_season["own_manager_name"].isin(managers)
+    ]
+        .groupby(["own_manager_name", "competition_type"])["pct_win"]
+        .mean()
+        .reset_index()
+)
+
+st.subheader("Comparative performance")
+
+# https://plotly.com/python/polar-chart/
+
+fig = px.line_polar(
+    managers_win_pct_comparative,
+    r="pct_win",
+    theta="competition_type",
+    color="own_manager_name",
+    line_close=True,
+    color_discrete_sequence=px.colors.sequential.Plasma_r,
+    template="plotly_dark"
+)
+st.plotly_chart(fig, use_container_width=True)
+
 
 # finally, diplay results in chart
 
 st.subheader(
-    f"Managers performance by season in national competitions"
+    f"Performance by season"
 )
 
-managers_win_pct_per_season_in_domestic_league = managers_win_pct_per_season[
-    managers_win_pct_per_season["competition_type"] == "domestic_league"
-]
+managers_win_pct_perf_by_season = (
+    managers_win_pct_per_season.groupby(
+        ["season", "own_manager_name", "club_pretty_name"]
+    )["total_games", "total_wins"].sum()
+    .reset_index()
+)
 
+managers_win_pct_perf_by_season["pct_win"] = (
+    managers_win_pct_perf_by_season["total_wins"] / managers_win_pct_perf_by_season["total_games"]
+)
 
 st.altair_chart(
-    altair_chart=alt.Chart(managers_win_pct_per_season_in_domestic_league).mark_bar().encode(
+    altair_chart=alt.Chart(managers_win_pct_perf_by_season).mark_bar().encode(
         x="year(season):T",
         y="own_manager_name:N",
         color=alt.Color(
             shorthand="pct_win",
             scale=alt.Scale(range=["red", "green"])
         ),
-        tooltip="club_pretty_name"
+        tooltip="club_pretty_name:N"
     ),
     use_container_width=True
 )
-
-st.subheader(
-    f"Managers performance by season in international competitions"
-)
-
-managers_win_pct_per_season_in_international_competitions = managers_win_pct_per_season[
-    managers_win_pct_per_season["competition_type"] == "international_cup"
-]
-
-st.altair_chart(
-    altair_chart=alt.Chart(managers_win_pct_per_season_in_international_competitions).mark_bar().encode(
-        x="year(season):T",
-        y="own_manager_name:N",
-        color=alt.Color(
-            shorthand="pct_win",
-            scale=alt.Scale(range=["red", "green"])
-        ),
-        tooltip="club_pretty_name"
-    ),
-    use_container_width=True
-)
-
-

--- a/streamlit/pages/04_📈_analysis:_manager_performance.py
+++ b/streamlit/pages/04_📈_analysis:_manager_performance.py
@@ -1,7 +1,5 @@
-from altair.vegalite.v4.api import value
 import streamlit as st
 import pandas as pd
-from traitlets import default
 
 from utils import read_file_contents, load_td
 

--- a/streamlit/pages/04_📈_analysis:_manager_performance.py
+++ b/streamlit/pages/04_📈_analysis:_manager_performance.py
@@ -37,6 +37,7 @@ DEFAULT_MANAGERS = ["Jürgen Klopp", "Pep Guardiola"]
 DEFAULT_COMPETITION_TYPES = [
     "domestic_cup", "domestic_league", "international_cup"
 ]
+DEFAULT_MIN_GAMES = 1
 
 with st.expander("Baseline Filters"):
 
@@ -65,7 +66,7 @@ with st.expander("Baseline Filters"):
     )
 
     minimun_number_of_games_played = (
-        col2.number_input('Minimum number of games played in a season', value=5)
+        col2.number_input('Minimum number of games played in a season', value=DEFAULT_MIN_GAMES)
     )
 
 # create a data mart with all required measures and dimensions

--- a/streamlit/utils.py
+++ b/streamlit/utils.py
@@ -14,9 +14,6 @@ sys.path.insert(0, cwd)
 from transfermarkt_datasets.core.dataset import Dataset
 from transfermarkt_datasets.core.asset import Asset
 
-# community components
-from streamlit_agraph import agraph, Node, Edge, Config
-
 @st.cache
 def load_td() -> Dataset:
     """Instantiate and initialise a Dataset, so it can be used in the app.

--- a/streamlit/utils.py
+++ b/streamlit/utils.py
@@ -14,6 +14,9 @@ sys.path.insert(0, cwd)
 from transfermarkt_datasets.core.dataset import Dataset
 from transfermarkt_datasets.core.asset import Asset
 
+# community components
+from streamlit_agraph import agraph, Node, Edge, Config
+
 @st.cache
 def load_td() -> Dataset:
     """Instantiate and initialise a Dataset, so it can be used in the app.

--- a/streamlit/utils.py
+++ b/streamlit/utils.py
@@ -4,7 +4,7 @@ import streamlit as st
 import os
 from pathlib import Path
 import pandas as pd
-from inflection import titleize
+from inflection import dasherize, titleize
 from datetime import datetime, timedelta
 
 import sys
@@ -54,7 +54,13 @@ def draw_asset(asset: Asset) -> None:
 
     left_col, right_col = st.columns([5,1])
 
-    left_col.subheader(titleize(asset.frictionless_resource_name))
+    title = titleize(asset.frictionless_resource_name)
+    anchor = dasherize(asset.frictionless_resource_name)
+
+    left_col.subheader(title)
+    st.sidebar.markdown(
+        f"[{title}](#{anchor})"
+    )
 
     left_col.markdown(asset.description)
     delta = get_records_delta(asset)
@@ -65,7 +71,7 @@ def draw_asset(asset: Asset) -> None:
         help="Total number of records in the asset / New records in the past week"
     )
 
-    with st.expander("Schema"):
+    with st.expander("Attributes"):
         draw_asset_schema(asset)
 
     with st.expander("Explore"):

--- a/streamlit/utils.py
+++ b/streamlit/utils.py
@@ -16,7 +16,6 @@ from transfermarkt_datasets.core.asset import Asset
 
 # community components
 from streamlit_agraph import agraph, Node, Edge, Config
-from st_aggrid import AgGrid
 
 @st.cache
 def load_td() -> Dataset:
@@ -66,6 +65,9 @@ def draw_asset(asset: Asset) -> None:
         help="Total number of records in the asset / New records in the past week"
     )
 
+    with st.expander("Schema"):
+        draw_asset_schema(asset)
+
     with st.expander("Explore"):
         draw_asset_explore(asset)
 
@@ -90,6 +92,13 @@ def draw_asset_explore(asset: Asset, columns: List[str] = None) -> None:
         df = df[df[at_col] == selected]
     
     st.dataframe(df)
+
+
+def draw_asset_schema(asset: Asset) -> None:
+    st.dataframe(
+        asset.schema_as_dataframe(),
+        use_container_width=True
+    )
 
 def draw_dataset_er_diagram(td: Dataset) -> None:
     nodes = []

--- a/transfermarkt_datasets/assets/base_appearances.py
+++ b/transfermarkt_datasets/assets/base_appearances.py
@@ -37,7 +37,7 @@ class BaseAppearancesAsset(RawAsset):
     self.schema.primary_key = ['appearance_id']
     
     self.schema.foreign_keys = [
-      {"fields": "game_id", "reference": {"resource": "games", "fields": "game_id"}}
+      {"fields": "game_id", "reference": {"resource": "base_games", "fields": "game_id"}}
     ]
 
     self.checks = [

--- a/transfermarkt_datasets/assets/base_appearances.py
+++ b/transfermarkt_datasets/assets/base_appearances.py
@@ -1,10 +1,10 @@
 import numpy
 import pandas
-from frictionless.schema import Schema
-from frictionless.field import Field
+
 from frictionless import checks
 
 from transfermarkt_datasets.core.asset import RawAsset
+from transfermarkt_datasets.core.schema import Schema, Field
 from transfermarkt_datasets.core.utils import (
   cast_metric, cast_minutes_played,
   read_config

--- a/transfermarkt_datasets/assets/base_clubs.py
+++ b/transfermarkt_datasets/assets/base_clubs.py
@@ -1,5 +1,3 @@
-from frictionless.field import Field
-from frictionless.schema import Schema
 from frictionless import checks
 from inflection import titleize
 
@@ -7,6 +5,7 @@ import pandas
 import numpy
 
 from transfermarkt_datasets.core.asset import RawAsset
+from transfermarkt_datasets.core.schema import Schema, Field
 
 class BaseClubsAsset(RawAsset):
 
@@ -45,7 +44,7 @@ class BaseClubsAsset(RawAsset):
     self.schema.add_field(Field(
       name='url',
       type='string',
-      format='uri'
+      form='uri'
       )
     )
 

--- a/transfermarkt_datasets/assets/base_competitions.py
+++ b/transfermarkt_datasets/assets/base_competitions.py
@@ -1,11 +1,10 @@
-from frictionless.field import Field
-from frictionless.schema import Schema
 from frictionless import checks
 
 import pandas as pd
 import numpy as np
 
 from transfermarkt_datasets.core.asset import RawAsset
+from transfermarkt_datasets.core.schema import Schema, Field
 
 class BaseCompetitionsAsset(RawAsset):
 
@@ -30,7 +29,7 @@ class BaseCompetitionsAsset(RawAsset):
     self.schema.add_field(Field(
         name='url',
         type='string',
-        format='uri'
+        form='uri'
       )
     )
 

--- a/transfermarkt_datasets/assets/base_games.py
+++ b/transfermarkt_datasets/assets/base_games.py
@@ -1,5 +1,3 @@
-from frictionless.field import Field
-from frictionless.schema import Schema
 from frictionless import checks
 
 from datetime import datetime
@@ -7,6 +5,7 @@ from datetime import datetime
 import pandas as pd
 
 from transfermarkt_datasets.core.asset import RawAsset
+from transfermarkt_datasets.core.schema import Schema, Field
 from transfermarkt_datasets.core.checks import too_many_missings
 
 class BaseGamesAsset(RawAsset):
@@ -40,7 +39,7 @@ class BaseGamesAsset(RawAsset):
     self.schema.add_field(Field(
         name='url',
         type='string',
-        format='uri'
+        form='uri'
       )
     )
 

--- a/transfermarkt_datasets/assets/base_player_valuations.py
+++ b/transfermarkt_datasets/assets/base_player_valuations.py
@@ -1,11 +1,10 @@
-from frictionless.field import Field
-from frictionless.schema import Schema
 from frictionless import checks
 from inflection import titleize
 
 import pandas
 
 from transfermarkt_datasets.core.asset import RawAsset
+from transfermarkt_datasets.core.schema import Schema, Field
 from transfermarkt_datasets.core.utils import parse_market_value
 
 class BasePlayerValuationsAsset(RawAsset):

--- a/transfermarkt_datasets/assets/base_players.py
+++ b/transfermarkt_datasets/assets/base_players.py
@@ -1,5 +1,3 @@
-from frictionless.field import Field
-from frictionless.schema import Schema
 from frictionless import checks
 
 from inflection import titleize
@@ -8,6 +6,7 @@ import pandas
 import numpy
 
 from transfermarkt_datasets.core.asset import RawAsset
+from transfermarkt_datasets.core.schema import Schema, Field
 from transfermarkt_datasets.core.utils import parse_market_value
 from transfermarkt_datasets.core.checks import too_many_missings
 
@@ -42,13 +41,13 @@ class BasePlayersAsset(RawAsset):
     self.schema.add_field(Field(
       name='image_url',
       type='string',
-      format='uri'
+      form='uri'
       )
     )
     self.schema.add_field(Field(
       name='url',
       type='string',
-      format='uri'
+      form='uri'
       )
     )
    

--- a/transfermarkt_datasets/assets/base_players.py
+++ b/transfermarkt_datasets/assets/base_players.py
@@ -53,7 +53,7 @@ class BasePlayersAsset(RawAsset):
     )
    
     self.schema.foreign_keys = [
-      {"fields": "current_club_id", "reference": {"resource": "clubs", "fields": "club_id"}}
+      {"fields": "current_club_id", "reference": {"resource": "base_clubs", "fields": "club_id"}}
     ]
 
     self.checks = [

--- a/transfermarkt_datasets/assets/cur_appearances.py
+++ b/transfermarkt_datasets/assets/cur_appearances.py
@@ -1,10 +1,9 @@
-from frictionless.field import Field
-from frictionless.schema import Schema
 from frictionless import checks
 
 import pandas as pd
 
 from transfermarkt_datasets.core.asset import Asset
+from transfermarkt_datasets.core.schema import Schema, Field
 from transfermarkt_datasets.assets.base_games import BaseGamesAsset
 from transfermarkt_datasets.assets.base_appearances import BaseAppearancesAsset
 from transfermarkt_datasets.assets.base_players import BasePlayersAsset

--- a/transfermarkt_datasets/assets/cur_appearances.py
+++ b/transfermarkt_datasets/assets/cur_appearances.py
@@ -29,6 +29,10 @@ class CurAppearancesAsset(Asset):
     self.schema.add_field(Field(name="player_pretty_name", type="string"))
 
     self.schema.primary_key = ["appearance_id"]
+
+    self.schema.foreign_keys = [
+      {"fields": "game_id", "reference": {"resource": "cur_games", "fields": "game_id"}}
+    ]
     
     self.checks = [
       checks.table_dimensions(min_rows=1000000)

--- a/transfermarkt_datasets/assets/cur_appearances.py
+++ b/transfermarkt_datasets/assets/cur_appearances.py
@@ -24,8 +24,8 @@ class CurAppearancesAsset(Asset):
 
     self.schema.add_field(Field(name="appearance_id", type="integer"))
     self.schema.add_field(Field(name="game_id", type="integer"))
-    self.schema.add_field(Field(name="date", type="date"))
-    self.schema.add_field(Field(name="player_pretty_name", type="string"))
+    self.schema.add_field(Field(name="date", type="date", tags=["explore"]))
+    self.schema.add_field(Field(name="player_pretty_name", type="string", tags=["explore"]))
 
     self.schema.primary_key = ["appearance_id"]
 

--- a/transfermarkt_datasets/assets/cur_club_games.py
+++ b/transfermarkt_datasets/assets/cur_club_games.py
@@ -1,6 +1,4 @@
 from typing import List
-from frictionless.field import Field
-from frictionless.schema import Schema
 from frictionless import checks
 
 from datetime import datetime
@@ -9,6 +7,7 @@ import pandas as pd
 import numpy as np
 
 from transfermarkt_datasets.core.asset import Asset
+from transfermarkt_datasets.core.schema import Schema, Field
 from transfermarkt_datasets.assets.base_games import BaseGamesAsset
 
 class CurClubGamesAsset(Asset):

--- a/transfermarkt_datasets/assets/cur_club_games.py
+++ b/transfermarkt_datasets/assets/cur_club_games.py
@@ -27,7 +27,6 @@ class CurClubGamesAsset(Asset):
 
     self.schema.add_field(Field(name='club_id', type='integer'))
     self.schema.add_field(Field(name='game_id', type='integer'))
-    self.schema.add_field(Field(name='date', type='date'))
     self.schema.add_field(Field(name='own_goals', type='integer'))
     self.schema.add_field(Field(name='own_position', type='integer'))
     self.schema.add_field(Field(name='own_manager_name', type="string"))

--- a/transfermarkt_datasets/assets/cur_club_games.py
+++ b/transfermarkt_datasets/assets/cur_club_games.py
@@ -39,8 +39,13 @@ class CurClubGamesAsset(Asset):
 
     self.schema.primary_key = ["club_id", "game_id"]
 
+    self.schema.foreign_keys = [
+      {"fields": "club_id", "reference": {"resource": "cur_clubs", "fields": "club_id"}},
+      {"fields": "game_id", "reference": {"resource": "cur_games", "fields": "game_id"}}
+    ]
+
     self.checks = [
-      checks.table_dimensions(min_rows=58028*2)
+      checks.table_dimensions(min_rows=58000*2)
     ]
 
   def build(self, base_games: BaseGamesAsset):

--- a/transfermarkt_datasets/assets/cur_club_games.py
+++ b/transfermarkt_datasets/assets/cur_club_games.py
@@ -28,7 +28,7 @@ class CurClubGamesAsset(Asset):
     self.schema.add_field(Field(name='game_id', type='integer'))
     self.schema.add_field(Field(name='own_goals', type='integer'))
     self.schema.add_field(Field(name='own_position', type='integer'))
-    self.schema.add_field(Field(name='own_manager_name', type="string"))
+    self.schema.add_field(Field(name='own_manager_name', type="string", tags=["explore"]))
     self.schema.add_field(Field(
       name="is_win",
       type="integer",

--- a/transfermarkt_datasets/assets/cur_clubs.py
+++ b/transfermarkt_datasets/assets/cur_clubs.py
@@ -52,7 +52,7 @@ class CurClubsAsset(Asset):
 
     self.schema.primary_key = ['club_id']
     self.schema.foreign_keys = [
-      {"fields": "domestic_competition_id", "reference": {"resource": "competitions", "fields": "competition_id"}}
+      {"fields": "domestic_competition_id", "reference": {"resource": "cur_competitions", "fields": "competition_id"}}
     ]
 
     self.checks = [

--- a/transfermarkt_datasets/assets/cur_clubs.py
+++ b/transfermarkt_datasets/assets/cur_clubs.py
@@ -1,5 +1,3 @@
-from frictionless.field import Field
-from frictionless.schema import Schema
 from frictionless import checks
 
 from datetime import datetime
@@ -7,6 +5,7 @@ from datetime import datetime
 import pandas as pd
 
 from transfermarkt_datasets.core.asset import Asset
+from transfermarkt_datasets.core.schema import Schema, Field
 from transfermarkt_datasets.assets.base_games import BaseGamesAsset
 from transfermarkt_datasets.assets.base_clubs import BaseClubsAsset
 
@@ -46,7 +45,7 @@ class CurClubsAsset(Asset):
     self.schema.add_field(Field(
       name='url',
       type='string',
-      format='uri'
+      form='uri'
       )
     )
 

--- a/transfermarkt_datasets/assets/cur_clubs.py
+++ b/transfermarkt_datasets/assets/cur_clubs.py
@@ -26,7 +26,7 @@ class CurClubsAsset(Asset):
     self.schema.add_field(Field(name='club_id', type='integer'))
     self.schema.add_field(Field(name='name', type='string'))
     self.schema.add_field(Field(name='pretty_name', type='string'))
-    self.schema.add_field(Field(name='domestic_competition_id', type='string'))
+    self.schema.add_field(Field(name='domestic_competition_id', type='string', tags=["explore"]))
     self.schema.add_field(Field(
         name='total_market_value',
         type='number',

--- a/transfermarkt_datasets/assets/cur_competitions.py
+++ b/transfermarkt_datasets/assets/cur_competitions.py
@@ -29,7 +29,7 @@ class CurCompetitionsAsset(RawAsset):
     self.schema.add_field(Field(name='country_latitude', type='number'))
     self.schema.add_field(Field(name='country_longitude', type='number'))
     self.schema.add_field(Field(name='domestic_league_code', type='string'))
-    self.schema.add_field(Field(name='confederation', type='string'))
+    self.schema.add_field(Field(name='confederation', type='string', tags=["explore"]))
     self.schema.add_field(Field(
         name='url',
         type='string',

--- a/transfermarkt_datasets/assets/cur_competitions.py
+++ b/transfermarkt_datasets/assets/cur_competitions.py
@@ -1,10 +1,9 @@
-from frictionless.field import Field
-from frictionless.schema import Schema
 from frictionless import checks
 
 import pandas as pd
 
 from transfermarkt_datasets.core.asset import RawAsset
+from transfermarkt_datasets.core.schema import Schema, Field
 from transfermarkt_datasets.core.utils import geocode
 
 from transfermarkt_datasets.assets.base_competitions import BaseCompetitionsAsset
@@ -34,7 +33,7 @@ class CurCompetitionsAsset(RawAsset):
     self.schema.add_field(Field(
         name='url',
         type='string',
-        format='uri'
+        form='uri'
       )
     )
 

--- a/transfermarkt_datasets/assets/cur_games.py
+++ b/transfermarkt_datasets/assets/cur_games.py
@@ -33,7 +33,7 @@ class CurGamesAsset(Asset):
     self.schema.add_field(Field(name='home_club_position', type='integer'))
     self.schema.add_field(Field(name='away_club_position', type='integer'))
     self.schema.add_field(Field(name='stadium', type='string'))
-    self.schema.add_field(Field(name='attendance', type='integer', tags=["explore"]))
+    self.schema.add_field(Field(name='attendance', type='integer'))
     self.schema.add_field(Field(name='referee', type='string'))
     self.schema.add_field(Field(name='club_home_pretty_name', type='string', tags=["explore"]))
     self.schema.add_field(Field(name='club_away_pretty_name', type='string', tags=["explore"]))

--- a/transfermarkt_datasets/assets/cur_games.py
+++ b/transfermarkt_datasets/assets/cur_games.py
@@ -1,12 +1,7 @@
-from frictionless.field import Field
-from frictionless.schema import Schema
 from frictionless import checks
 
-from datetime import datetime
-
-import pandas as pd
-
 from transfermarkt_datasets.core.asset import Asset
+from transfermarkt_datasets.core.schema import Schema, Field
 from transfermarkt_datasets.assets.base_games import BaseGamesAsset
 from transfermarkt_datasets.assets.base_clubs import BaseClubsAsset
 from transfermarkt_datasets.assets.base_competitions import BaseCompetitionsAsset
@@ -45,7 +40,7 @@ class CurGamesAsset(Asset):
     self.schema.add_field(Field(
         name='url',
         type='string',
-        format='uri'
+        form='uri'
       )
     )
 

--- a/transfermarkt_datasets/assets/cur_games.py
+++ b/transfermarkt_datasets/assets/cur_games.py
@@ -21,10 +21,10 @@ class CurGamesAsset(Asset):
     self.schema = Schema()
 
     self.schema.add_field(Field(name='game_id', type='integer'))
-    self.schema.add_field(Field(name='competition_id', type='string'))
-    self.schema.add_field(Field(name='season', type='integer'))
-    self.schema.add_field(Field(name='round', type='string'))
-    self.schema.add_field(Field(name='date', type='date'))
+    self.schema.add_field(Field(name='competition_id', type='string', tags=["explore"]))
+    self.schema.add_field(Field(name='season', type='integer', tags=["explore"]))
+    self.schema.add_field(Field(name='round', type='string', tags=["explore"]))
+    self.schema.add_field(Field(name='date', type='date', tags=["explore"]))
     self.schema.add_field(Field(name='home_club_id', type='integer'))
     self.schema.add_field(Field(name='away_club_id', type='integer'))
     self.schema.add_field(Field(name='home_club_goals', type='integer'))
@@ -33,10 +33,10 @@ class CurGamesAsset(Asset):
     self.schema.add_field(Field(name='home_club_position', type='integer'))
     self.schema.add_field(Field(name='away_club_position', type='integer'))
     self.schema.add_field(Field(name='stadium', type='string'))
-    self.schema.add_field(Field(name='attendance', type='integer'))
+    self.schema.add_field(Field(name='attendance', type='integer', tags=["explore"]))
     self.schema.add_field(Field(name='referee', type='string'))
-    self.schema.add_field(Field(name='club_home_pretty_name', type='string'))
-    self.schema.add_field(Field(name='club_away_pretty_name', type='string'))
+    self.schema.add_field(Field(name='club_home_pretty_name', type='string', tags=["explore"]))
+    self.schema.add_field(Field(name='club_away_pretty_name', type='string', tags=["explore"]))
     self.schema.add_field(Field(
         name='url',
         type='string',

--- a/transfermarkt_datasets/assets/cur_player_valuations.py
+++ b/transfermarkt_datasets/assets/cur_player_valuations.py
@@ -32,7 +32,7 @@ class CurPlayerValuationsAsset(Asset):
 
     self.schema.primary_key = ['player_id', 'date']
     self.schema.foreign_keys = [
-      {"fields": "player_id", "reference": {"resource": "players", "fields": "player_id"}}
+      {"fields": "player_id", "reference": {"resource": "cur_players", "fields": "player_id"}}
     ]
 
     self.checks = [

--- a/transfermarkt_datasets/assets/cur_player_valuations.py
+++ b/transfermarkt_datasets/assets/cur_player_valuations.py
@@ -1,10 +1,9 @@
-from frictionless.field import Field
-from frictionless.schema import Schema
 from frictionless import checks
 
 import pandas as pd
 
 from transfermarkt_datasets.core.asset import Asset
+from transfermarkt_datasets.core.schema import Schema, Field
 from transfermarkt_datasets.assets.base_player_valuations import BasePlayerValuationsAsset
 from transfermarkt_datasets.assets.base_players import BasePlayersAsset
 from transfermarkt_datasets.assets.base_clubs import BaseClubsAsset

--- a/transfermarkt_datasets/assets/cur_player_valuations.py
+++ b/transfermarkt_datasets/assets/cur_player_valuations.py
@@ -27,7 +27,11 @@ class CurPlayerValuationsAsset(Asset):
     self.schema.add_field(Field(name='dateweek', type='date'))
     self.schema.add_field(Field(name='player_id', type='integer'))
     self.schema.add_field(Field(name='market_value', type='number'))
-    self.schema.add_field(Field(name='player_club_domestic_competition_id', type='string'))
+    self.schema.add_field(Field(
+      name='player_club_domestic_competition_id',
+      type='string',
+      tags=["explore"]
+    ))
 
     self.schema.primary_key = ['player_id', 'date']
     self.schema.foreign_keys = [

--- a/transfermarkt_datasets/assets/cur_players.py
+++ b/transfermarkt_datasets/assets/cur_players.py
@@ -64,8 +64,8 @@ class CurPlayersAsset(RawAsset):
 
     self.schema.primary_key = ['player_id']
     self.schema.foreign_keys = [
-      {"fields": "current_club_id", "reference": {"resource": "clubs", "fields": "club_id"}},
-      {"fields": "domestic_competition_id", "reference": {"resource": "competition", "fields": "competition_id"}},
+      {"fields": "current_club_id", "reference": {"resource": "cur_clubs", "fields": "club_id"}},
+      {"fields": "domestic_competition_id", "reference": {"resource": "cur_competition", "fields": "competition_id"}},
     ]
 
     self.checks = [

--- a/transfermarkt_datasets/assets/cur_players.py
+++ b/transfermarkt_datasets/assets/cur_players.py
@@ -1,5 +1,3 @@
-from frictionless.field import Field
-from frictionless.schema import Schema
 from frictionless import checks
 
 from inflection import titleize
@@ -8,6 +6,7 @@ import pandas
 import numpy
 
 from transfermarkt_datasets.core.asset import RawAsset
+from transfermarkt_datasets.core.schema import Schema, Field
 from transfermarkt_datasets.core.utils import parse_market_value
 from transfermarkt_datasets.core.checks import too_many_missings
 
@@ -52,13 +51,13 @@ class CurPlayersAsset(RawAsset):
     self.schema.add_field(Field(
       name='image_url',
       type='string',
-      format='uri'
+      form='uri'
       )
     )
     self.schema.add_field(Field(
       name='url',
       type='string',
-      format='uri'
+      form='uri'
       )
     )
 

--- a/transfermarkt_datasets/assets/cur_players.py
+++ b/transfermarkt_datasets/assets/cur_players.py
@@ -33,21 +33,21 @@ class CurPlayersAsset(RawAsset):
 
     self.schema.add_field(Field(name='player_id', type='integer'))
     self.schema.add_field(Field(name='last_season', type='integer'))
-    self.schema.add_field(Field(name='current_club_id', type='integer'))
+    self.schema.add_field(Field(name='current_club_id', type='integer', tags=["explore"]))
     self.schema.add_field(Field(name='name', type='string'))
     self.schema.add_field(Field(name='pretty_name', type='string'))
-    self.schema.add_field(Field(name='country_of_birth', type='string'))
+    self.schema.add_field(Field(name='country_of_birth', type='string', tags=["explore"]))
     self.schema.add_field(Field(name='country_of_citizenship', type='string'))
     self.schema.add_field(Field(name='date_of_birth', type='date'))
-    self.schema.add_field(Field(name='position', type='string'))
-    self.schema.add_field(Field(name='sub_position', type='string'))
-    self.schema.add_field(Field(name='foot', type='string'))
+    self.schema.add_field(Field(name='position', type='string', tags=["explore"]))
+    self.schema.add_field(Field(name='sub_position', type='string', tags=["explore"]))
+    self.schema.add_field(Field(name='foot', type='string', tags=["explore"]))
     self.schema.add_field(Field(name='height_in_cm', type='integer'))
     self.schema.add_field(Field(name='market_value_in_gbp', type='number'))
     self.schema.add_field(Field(name='highest_market_value_in_gbp', type='number'))
     self.schema.add_field(Field(name='agent_name', type='string'))
     self.schema.add_field(Field(name='domestic_competition_id', type='string'))
-    self.schema.add_field(Field(name='club_name', type='string'))
+    self.schema.add_field(Field(name='club_name', type='string', tags=["explore"]))
     self.schema.add_field(Field(
       name='image_url',
       type='string',

--- a/transfermarkt_datasets/core/asset.py
+++ b/transfermarkt_datasets/core/asset.py
@@ -1,21 +1,27 @@
 from typing import Dict, List
-from dagster import DependencyDefinition, InputDefinition, OpDefinition, Output, OutputDefinition
+from dagster import (
+  DependencyDefinition,
+  InputDefinition,
+  OpDefinition,
+  Output,
+  OutputDefinition
+)
 from frictionless import Detector
 from frictionless.resource import Resource
 import pandas as pd
 import logging
 import logging.config
 
-from frictionless.package import Package
 from frictionless import validate
 from frictionless.schema import Schema
 
 import json
 import inspect
 
-import public
-
-from transfermarkt_datasets.core.utils import read_config
+from transfermarkt_datasets.core.utils import (
+  read_config,
+  get_sample_values
+)
 
 class FailedAssetValidation(Exception):
   pass
@@ -147,11 +153,16 @@ class Asset:
     fields = [field.name for field in  self.schema["fields"]]
     types = [field.type for field in  self.schema["fields"]]
     descriptions = [field.description for field in  self.schema["fields"]]
+    sample_values = [
+      get_sample_values(self.prep_df, field.name, 3)
+      for field in self.schema["fields"]
+    ]
 
     df = pd.DataFrame(
       data=dict(
         description=descriptions,
-        type=types
+        type=types,
+        sample_values=sample_values
       ),
       index=fields
     )

--- a/transfermarkt_datasets/core/asset.py
+++ b/transfermarkt_datasets/core/asset.py
@@ -8,6 +8,7 @@ import logging.config
 
 from frictionless.package import Package
 from frictionless import validate
+from frictionless.schema import Schema
 
 import json
 import inspect
@@ -49,7 +50,7 @@ class Asset:
         file_name = self.name.replace("base_", "")
         self.file_name = file_name + ".csv"
 
-      self.schema = None
+      self.schema = Schema()
 
   def __str__(self) -> str:
       return f'Asset(name={self.name})'

--- a/transfermarkt_datasets/core/asset.py
+++ b/transfermarkt_datasets/core/asset.py
@@ -170,6 +170,7 @@ class Asset:
     return df
 
   def as_frictionless_resource(self) -> Resource:
+
     detector = Detector(schema_sync=True)
     resource = Resource(
       title=self.frictionless_resource_name,
@@ -177,9 +178,10 @@ class Asset:
       trusted=True,
       detector=detector,
       description=self.description,
-      basepath="transfermarkt_datasets/stage"
+      basepath="transfermarkt_datasets/stage",
+      schema=self.schema.as_frictionless_schema()
     )
-    resource.schema = self.schema.as_frictionless_schema()
+
     return resource
 
   def as_build_dagster_op(self) -> OpDefinition:

--- a/transfermarkt_datasets/core/asset.py
+++ b/transfermarkt_datasets/core/asset.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict
 from dagster import (
   DependencyDefinition,
   InputDefinition,
@@ -13,7 +13,7 @@ import logging
 import logging.config
 
 from frictionless import validate
-from frictionless.schema import Schema
+from transfermarkt_datasets.core.schema import Schema, Field
 
 import json
 import inspect
@@ -150,12 +150,12 @@ class Asset:
         pd.DataFrame: A pandas dataframe representing the asset schema.
     """
 
-    fields = [field.name for field in  self.schema["fields"]]
-    types = [field.type for field in  self.schema["fields"]]
-    descriptions = [field.description for field in  self.schema["fields"]]
+    fields = [field.name for field in  self.schema.fields]
+    types = [field.type for field in  self.schema.fields]
+    descriptions = [field.description for field in  self.schema.fields]
     sample_values = [
       get_sample_values(self.prep_df, field.name, 3)
-      for field in self.schema["fields"]
+      for field in self.schema.fields
     ]
 
     df = pd.DataFrame(
@@ -179,7 +179,7 @@ class Asset:
       description=self.description,
       basepath="transfermarkt_datasets/stage"
     )
-    resource.schema = self.schema
+    resource.schema = self.schema.as_frictionless_schema()
     return resource
 
   def as_build_dagster_op(self) -> OpDefinition:

--- a/transfermarkt_datasets/core/schema.py
+++ b/transfermarkt_datasets/core/schema.py
@@ -9,39 +9,63 @@ class Field:
         name: str,
         type: str,
         description: str = None,
+        tags: List[str] = None,
         form: str = None) -> None:
         
         self.name = name
         self.type = type
         self.description = description
         self.form = form
+        self.tags = tags or []
 
-    def as_frictionless_field(self) -> frictionless.Field:
-        fl_field = frictionless.Field(
+    def __eq__(self, __o: object) -> bool:
+        return self.name == __o.name
+
+    def as_frictionless_field(self) -> frictionless.field.Field:
+        fl_field = frictionless.field.Field(
             name=self.name,
             type=self.type,
-            description=self.description
-            # format=self.form
+            description=self.description,
+            format=self.form
         )
         return fl_field
 
+    def has_tag(self, tag: str) -> bool:
+        if tag in self.tags:
+            return True
+        else:
+            return False
+
 class Schema:
-    def __init__(self, fields: List[Field] = []) -> None:
-        self.fields: List[Field] = fields
-        self.primary_key: List[str] = []
-        self.foreign_keys: List[str] = []
+    def __init__(
+        self,
+        fields: List[Field] = None,
+        primary_key: List[str] = None,
+        foreign_keys: List[str] = None) -> None:
+
+        self.fields = fields or []
+        self.primary_key = primary_key or []
+        self.foreign_keys = foreign_keys or []
     
     def add_field(self, field: Field) -> None:
         self.fields.append(
             field
         )
 
-    def as_frictionless_schema(self) -> frictionless.Schema:
+    def get_fields_by_tag(self, tag: str) -> List[Field]:
+
+        matched_tag = [
+            field for field in self.fields if field.has_tag(tag)
+        ]
+
+        return matched_tag
+
+    def as_frictionless_schema(self) -> frictionless.schema.Schema:
 
         fl_fields = [field.as_frictionless_field()
             for field in self.fields
         ]
-        fl_schema = frictionless.Schema(
+        fl_schema = frictionless.schema.Schema(
             fields=fl_fields
         )
         

--- a/transfermarkt_datasets/core/schema.py
+++ b/transfermarkt_datasets/core/schema.py
@@ -1,0 +1,50 @@
+
+from typing import List
+
+import frictionless
+
+class Field:
+    def __init__(
+        self,
+        name: str,
+        type: str,
+        description: str = None,
+        form: str = None) -> None:
+        
+        self.name = name
+        self.type = type
+        self.description = description
+        self.form = form
+
+    def as_frictionless_field(self) -> frictionless.Field:
+        fl_field = frictionless.Field(
+            name=self.name,
+            type=self.type,
+            description=self.description
+            # format=self.form
+        )
+        return fl_field
+
+class Schema:
+    def __init__(self, fields: List[Field] = []) -> None:
+        self.fields: List[Field] = fields
+        self.primary_key: List[str] = []
+        self.foreign_keys: List[str] = []
+    
+    def add_field(self, field: Field) -> None:
+        self.fields.append(
+            field
+        )
+
+    def as_frictionless_schema(self) -> frictionless.Schema:
+
+        fl_schema = frictionless.Schema()
+        for field in self.fields:
+            fl_schema.add_field(
+                field.as_frictionless_field()
+            )
+        
+        return fl_schema
+
+
+

--- a/transfermarkt_datasets/core/schema.py
+++ b/transfermarkt_datasets/core/schema.py
@@ -38,11 +38,12 @@ class Schema:
 
     def as_frictionless_schema(self) -> frictionless.Schema:
 
-        fl_schema = frictionless.Schema()
-        for field in self.fields:
-            fl_schema.add_field(
-                field.as_frictionless_field()
-            )
+        fl_fields = [field.as_frictionless_field()
+            for field in self.fields
+        ]
+        fl_schema = frictionless.Schema(
+            fields=fl_fields
+        )
         
         return fl_schema
 

--- a/transfermarkt_datasets/core/utils.py
+++ b/transfermarkt_datasets/core/utils.py
@@ -2,8 +2,9 @@
 """
 
 import re
+from pandas import DataFrame
 import yaml
-from typing import Dict, Tuple
+from typing import Dict, Tuple, List
 
 import boto3
 from time import sleep
@@ -156,3 +157,6 @@ def geocode(place: str) -> Tuple:
 	output = geocode(place)
 
 	return (output.latitude, output.longitude)
+
+def get_sample_values(df: DataFrame, column: str, n: int) -> List[object]:
+	return list(df[column].unique())[:3]

--- a/transfermarkt_datasets/tests/test_assets.py
+++ b/transfermarkt_datasets/tests/test_assets.py
@@ -122,12 +122,22 @@ class TestAsset(unittest.TestCase):
                 )
         
         at = TestAsset()
+        at.prep_df = pd.DataFrame(
+            data={
+                "some_field": [1, 2],
+                "some_other_field": ["b", "c"],
+            }
+        )
         df = at.schema_as_dataframe()
 
         df_expected = pd.DataFrame(
             data={
                 "description": ["", ""],
-                "type": ["string", "integer"]
+                "type": ["string", "integer"],
+                "sample_values": [
+                    [1,2],
+                    ["b", "c"]
+                ]
             },
             index=["some_field", "some_other_field"]
         )

--- a/transfermarkt_datasets/tests/test_assets.py
+++ b/transfermarkt_datasets/tests/test_assets.py
@@ -3,8 +3,7 @@ import unittest
 
 from dagster import DependencyDefinition
 
-from frictionless.schema import Schema
-from frictionless.field import Field
+from transfermarkt_datasets.core.schema import Schema, Field
 
 import inspect
 
@@ -132,7 +131,7 @@ class TestAsset(unittest.TestCase):
 
         df_expected = pd.DataFrame(
             data={
-                "description": ["", ""],
+                "description": [None, None],
                 "type": ["string", "integer"],
                 "sample_values": [
                     [1,2],

--- a/transfermarkt_datasets/tests/test_dataset.py
+++ b/transfermarkt_datasets/tests/test_dataset.py
@@ -164,8 +164,8 @@ class BaseSomethingAsset(Asset):
                 "from": "base_something_a",
                 "to": "base_something_b",
                 "on": {
-                    "source": ["some_id"],
-                    "target": ["some_other_id"]
+                    "source": "some_id",
+                    "target": "some_other_id"
                 }
             }
         )

--- a/transfermarkt_datasets/tests/test_schema.py
+++ b/transfermarkt_datasets/tests/test_schema.py
@@ -1,0 +1,51 @@
+import unittest
+
+from transfermarkt_datasets.core.schema import Schema, Field
+
+import frictionless
+
+class TestSchema(unittest.TestCase):
+
+    def test_add_field(self):
+
+        schema = Schema()
+        self.assertEquals(
+            len(schema.fields),
+            0
+        )
+
+        field = Field(name="name", type="type")
+        schema.add_field(
+            field
+        )
+
+        self.assertEqual(
+            len(schema.fields),
+            1
+        )
+
+    def test_as_frictionless_schema(self):
+
+        schema = Schema()
+        schema.add_field(
+            Field(
+                name="some_name",
+                type="some_type"
+            )
+        )
+
+        self.assertIsInstance(
+            schema.as_frictionless_schema(),
+            frictionless.Schema
+        )
+
+        fl_schema = frictionless.Schema()
+        fl_schema.add_field(frictionless.Field(
+            name="some_name",
+            type="some_type"
+        ))
+        
+        self.assertEqual(
+            schema.as_frictionless_schema(),
+            fl_schema
+        )

--- a/transfermarkt_datasets/tests/test_schema.py
+++ b/transfermarkt_datasets/tests/test_schema.py
@@ -2,7 +2,8 @@ import unittest
 
 from transfermarkt_datasets.core.schema import Schema, Field
 
-import frictionless
+from frictionless.schema import Schema as FLSchema
+from frictionless.field import Field as FLField
 
 class TestSchema(unittest.TestCase):
 
@@ -36,16 +37,31 @@ class TestSchema(unittest.TestCase):
 
         self.assertIsInstance(
             schema.as_frictionless_schema(),
-            frictionless.Schema
+            FLSchema
         )
 
-        fl_schema = frictionless.Schema()
-        fl_schema.add_field(frictionless.Field(
+        fl_schema = FLSchema()
+        fl_schema.add_field(FLField(
             name="some_name",
             type="some_type"
         ))
         
+        as_fl_schema = schema.as_frictionless_schema()
         self.assertEqual(
-            schema.as_frictionless_schema(),
+            as_fl_schema,
             fl_schema
+        )
+
+    def test_get_fiedls_by_tag(self):
+
+        schema = Schema(
+            fields=[
+                Field(name="f1", type="t1", tags=["t1"]),
+                Field(name="f2", type="t1", tags=["t2"]),
+            ]
+        )
+
+        self.assertEqual(
+            schema.get_fields_by_tag("t2"),
+            [Field(name="f2", type="t1", tags=["t1"])]
         )


### PR DESCRIPTION
### Summary
Add a radar / polar graph comparator for manager performance in `04_📈_analysis:_manager_performance.py`. Such graph is helpful for comparing a manager performance to other managers across different competitions.

 
<img width="1706" alt="image" src="https://user-images.githubusercontent.com/16071835/199290550-bb9922d4-de7d-4c47-86ea-1e88155b5c2c.png">

Closes #110 

### Bonus
* Add an asset schema tab in the explore page
* Improve exploration