### PR TITLE
Add `transfermarkt-scraper` as poetry dependency

### DIFF
--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -55,7 +55,6 @@ jobs:
           DAY=$(date +"%Y-%m-%d")
           if [ $BRANCH = master ]; then
             JOB_DEFINITION_NAME=transfermarkt-datasets-batch-job-definition-master
-            ARGS="--asset all --seasons 2022"
           else
             JOB_DEFINITION_NAME=transfermarkt-datasets-batch-job-definition-dev
           fi

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "transfermarkt-scraper"]
-	path = transfermarkt-scraper
-	url = git@github.com:dcaribou/transfermarkt-scraper.git

--- a/1_acquire.py
+++ b/1_acquire.py
@@ -49,9 +49,9 @@ class Asset():
   
   def file_path(self, season):
     if self.name == 'competitions':
-      return pathlib.Path(f"../data/competitions.json")
+      return pathlib.Path(f"data/competitions.json")
     else:
-      return pathlib.Path(f"../data/raw/{season}/{self.name}.json")
+      return pathlib.Path(f"data/raw/{season}/{self.name}.json")
   
   def file_full_path(self, season):
     return str(self.file_path(season).absolute())
@@ -137,7 +137,7 @@ def acquire_on_local(asset, seasons, func):
     def crawl():
       for season in seasons:
         # if there's no path created yet for this season create one
-        season_path = pathlib.Path(f"../data/raw/{season}")
+        season_path = pathlib.Path(f"data/raw/{season}")
         if not season_path.exists():
           season_path.mkdir()
 
@@ -166,8 +166,6 @@ def acquire_on_local(asset, seasons, func):
   expanded_seasons = seasons_list(seasons)
   expanded_assets = assets_list(asset)
 
-  os.chdir("transfermarkt-scraper")
-
   # define crawler settings
   settings = get_project_settings()
   
@@ -175,16 +173,15 @@ def acquire_on_local(asset, seasons, func):
   settings.set("FEED_URI", None)
   settings.set("FEED_URI_PARAMS", "tfmkt.utils.uri_params")
   settings.set("FEEDS",{
-    "../data/raw/%(season)s/%(name)s.json": {
+    "data/raw/%(season)s/%(name)s.json": {
       "format": "jsonlines"
     }
   })
   settings.set("LOG_LEVEL", "INFO")
+  settings.set("SPIDER_MODULES", ["tfmkt"])
 
   # create crawlers and wait until they complete
   issue_crawlers_and_wait(expanded_assets, expanded_seasons, settings)
-
-  os.chdir("..")
 
 def acquire_on_cloud(job_name, job_queue, job_definition, branch, message, args, func):
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ In the scope of this project, "acquiring" is the process of collecting "raw data
 ```console
 python 1_acquire.py local --asset all --seasons 2022
 ```
-
-This dependency on [trasfermarkt-scraper](https://github.com/dcaribou/transfermarkt-scraper) is the reason why it exists as a sub-module in this project. The `1_acquire.py` is simply a helper script that runs the scraper with a set of parameters and collects the output in `data/raw`.
+The `1_acquire.py` is a helper script that runs the scraper with a set of parameters and collects the output in `data/raw`.
 
 ## data preparation
 In the scope of this project, "preparing" is the process of transforming raw data to create a high quality dataset that can be conveniently consumed by analysts of all kinds. The `transfermark_datasets` module contains the preparation logic, which can be executed using the `2_prepare.py` script.
@@ -125,8 +124,8 @@ Define all the necessary infrastructure for the project in the cloud with Terraf
 
 ## contributing :pray:
 Contributions to `transfermarkt-datasets` are most welcome. If you want to contribute new fields or assets to this dataset, instructions are quite simple:
-1. [Fork the repo](https://github.com/dcaribou/transfermarkt-datasets/fork) (make sure to initialize sub-modules as well with `git submodule update --init --recursive`)
+1. [Fork the repo](https://github.com/dcaribou/transfermarkt-datasets/fork)
 2. Set up your [local environment](##setup)
 3. Pull the raw data by either running `dvc pull` ([requesting access is needed](#dvc)) or using the `1_acquire.py` script (no access request needed)
-4. Start modifying assets or creating a new one in `transfermarkt_datasets/assets`. You can use `2_prepare.py` to run and test your changes.
+4. Start modifying assets or creating new ones in `transfermarkt_datasets/assets`. You can use `2_prepare.py` to run and test your changes.
 5. If it's all looking good, create a pull request with your changes :rocket:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Setup your local environment to run the project with `poetry`.
 1. Install [poetry](https://python-poetry.org/docs/)
 2. Clone the repo
 ```console
-git clone --recursive git@github.com:dcaribou/transfermarkt-datasets.git
+git clone git@github.com:dcaribou/transfermarkt-datasets.git
 ```
 3. Install project dependencies in a virtual environment
 ```console

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,7 +13,7 @@ if ! [ -d $PROJECT_HOME ]; then
     if ! [ -z ${BRANCH+x} ]; then
         eval `ssh-agent -s`
         ssh-add - <<< $(aws --region eu-west-1 secretsmanager get-secret-value --secret-id /ssh/transfermarkt-datasets/deploy-keys | jq -r '.SecretString')
-        git clone --recursive --branch $BRANCH git@github.com:dcaribou/transfermarkt-datasets.git
+        git clone --branch $BRANCH git@github.com:dcaribou/transfermarkt-datasets.git
         cd $PROJECT_HOME
     else
         echo "BRANCH is required to bootstrap the environment"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,17 +10,16 @@ frictionless = "4.40.8"
 pandas = "^1.4.2"
 boto3 = "^1.0.4"
 inflection = "^0.5.1"
-python-dateutil = "^2.8.2"
 pytest = "^7.1.2"
 dagster = "^0.14.13"
 dvc = {extras = ["s3"], version = "^2.17.0"}
 scipy = "^1.8.0"
 kaggle = "^1.5.12"
-Scrapy = "^2.6.2"
 streamlit = "1.15.2"
 geopy = "^2.2.0"
 plotly = "^5.11.0"
 streamlit-agraph = "^0.0.42"
+transfermarkt-scraper = {git = "git@github.com:dcaribou/transfermarkt-scraper.git", branch = "poetry"}
 
 [tool.poetry.dev-dependencies]
 jupyter = "^1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ streamlit = "1.15.2"
 geopy = "^2.2.0"
 plotly = "^5.11.0"
 streamlit-agraph = "^0.0.42"
-transfermarkt-scraper = {git = "git@github.com:dcaribou/transfermarkt-scraper.git", branch = "poetry"}
+transfermarkt-scraper = {git = "git@github.com:dcaribou/transfermarkt-scraper.git", tag = "v0.4.0"}
 
 [tool.poetry.dev-dependencies]
 jupyter = "^1.0.0"


### PR DESCRIPTION
Rather than using a submodule, let's take advantage of poetry to define `transfermarkt-scraper` as a dependency.

## TODOs:
- [x] Update README
- [x] Release a poetryish `transfermarkt-scraper` version