### PR TITLE
Minimise pulled data during CI build

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
         
           poetry run dvc pull data/prep
-          poetry run pytest -k "not build_all"
+          poetry run pytest -k "not build_all and not load"
 
       - name: image build
         env:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -37,7 +37,7 @@ jobs:
           AWS_EC2_METADATA_DISABLED: true # https://github.com/aws/aws-cli/issues/5262
         run: |
         
-          poetry run dvc pull
+          poetry run dvc pull data/prep
           poetry run pytest -k "not build_all"
 
       - name: image build
@@ -101,7 +101,7 @@ jobs:
           AWS_EC2_METADATA_DISABLED: true # https://github.com/aws/aws-cli/issues/5262
         run: |
           source .venv/bin/activate
-          dvc pull
+          dvc pull data/prep
           make \
             sync \
               MESSAGE="${{ github.event.head_commit.message }}"


### PR DESCRIPTION
Pulling the whole data folder during all CI steps seems unnecessary and it's adding up to a bunch of transfer costs. This PR aims to reduce the amount of data that gets pulled from remote storage at CI time.