### PR TITLE
Pin `transfermarkt-scraper` to main branch instead of tag

### DIFF
--- a/data/raw.dvc
+++ b/data/raw.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: d7f5afb43e32945aa5e98a9824593ca5.dir
-  size: 3784139630
+- md5: 068a7fe3e5bd7ad4caa4583165b714c4.dir
+  size: 3760792994
   nfiles: 44
   path: raw

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ streamlit = "1.15.2"
 geopy = "^2.2.0"
 plotly = "^5.11.0"
 streamlit-agraph = "^0.0.42"
-transfermarkt-scraper = {git = "https://github.com/dcaribou/transfermarkt-scraper.git", tag = "v0.4.0"}
+transfermarkt-scraper = {git = "https://github.com/dcaribou/transfermarkt-scraper.git", branch = "main"}
 
 [tool.poetry.dev-dependencies]
 jupyter = "^1.0.0"


### PR DESCRIPTION
Closes #139 

This will make sure that the latest version of the scraper is used when creating the image.