### PR TITLE
Upgrade `transfermarkt-scraper` module

### DIFF
--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: e551ccf93edef3d950bc17272a13de87.dir
-  size: 58014016
+- md5: b313ca8941eaf4af475f346ed023871c.dir
+  size: 58790536
   nfiles: 9
   path: prep

--- a/data/raw.dvc
+++ b/data/raw.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: dde62e19343aac73fde55ec83ae8ce61.dir
-  size: 200794666
-  nfiles: 48
+- md5: daea81afbc2f1260f69ee81a91eac8ab.dir
+  size: 207626449
+  nfiles: 50
   path: raw

--- a/data/raw.dvc
+++ b/data/raw.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: daea81afbc2f1260f69ee81a91eac8ab.dir
-  size: 207626449
-  nfiles: 50
+- md5: f2de8c4d7b0af751ec9692dd07fba453.dir
+  size: 207614153
+  nfiles: 48
   path: raw

--- a/dbt/models/curated/models.yml
+++ b/dbt/models/curated/models.yml
@@ -37,10 +37,11 @@ models:
                   date_trunc('month', "date")
               # the rationale for the filter below is
               # - exclude months of may, june, july, december and january many competitions stop on those dates and thresholds might not be reached
-              # - exclude 2020 becase many competitions stopped as well due to the pandemic
+              # - exclude 2020 because many competitions stopped as well due to the pandemic
+              # - exclude 2023 because its the ongoing season
               row_condition: >
                 date_part('month', "date") not in (5, 6, 7, 12, 1) and
-                date_part('year', "date") != 2020
+                date_part('year', "date") not in (2020, 2023)
       - name: game_id
         tests:
           - not_null
@@ -135,8 +136,8 @@ models:
             - last_season
             - url
       - dbt_expectations.expect_table_row_count_to_be_between:
-          min_value: 28000
-          max_value: 30000
+          min_value: 30000
+          max_value: 32000
     columns:
       - name: player_id
         tests:
@@ -178,8 +179,8 @@ models:
             - market_value_in_eur
             - player_club_domestic_competition_id
       - dbt_expectations.expect_table_row_count_to_be_between:
-          min_value: 400000
-          max_value: 440000
+          min_value: 430000
+          max_value: 460000
     columns:
       - name: player_id
         tests:

--- a/poetry.lock
+++ b/poetry.lock
@@ -6207,7 +6207,7 @@ Scrapy = "2.7.1"
 type = "git"
 url = "https://github.com/dcaribou/transfermarkt-scraper.git"
 reference = "main"
-resolved_reference = "7010369b4f3f485e9a871f7e700e91255b37572c"
+resolved_reference = "029afc2c2d83e323aec1eab328adfd8d4cbeb566"
 
 [[package]]
 name = "twisted"

--- a/transfermarkt_datasets/datapackage_description.md
+++ b/transfermarkt_datasets/datapackage_description.md
@@ -2,9 +2,9 @@
 > Clean, structured and **automatically updated** football data from [Transfermarkt](https://www.transfermarkt.co.uk/), including
 > * `60,000+` games from many seasons on all major competitions
 > * `400+` clubs from those competitions
-> * `28,000+` players from those clubs
-> * `300,000+` player market valuations historical records
-> * `1,000,000+` player appearance records from all games
+> * `30,000+` players from those clubs
+> * `400,000+` player market valuations historical records
+> * `1,200,000+` player appearance records from all games
 > 
 > and more!
 


### PR DESCRIPTION
Upgrade the `transfermarkt-scraper` module.
Relates to #191.

## Bonus
- [x] Backfill missing player data from seasion 2023 caused by the outdated library