### PR TITLE
Disable updates on `player_valuations` asset

### DIFF
--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: a5fbafb7558c2ab12da82caeaee98455.dir
+- md5: d114f49bba0eff399b0d4525936ccfd5.dir
   size: 59222918
   nfiles: 9
   path: prep

--- a/dbt/macros/helpers.sql
+++ b/dbt/macros/helpers.sql
@@ -1,0 +1,18 @@
+{#
+    Get a model configuration from the node graph
+    https://docs.getdbt.com/reference/dbt-jinja-functions/graph#accessing-models
+
+    Arguments:
+        - model_name: the name of the models to be fetched
+#}
+{% macro get_model_config(model_name) %}
+    {% if execute %}
+        {% for node in graph.nodes.values() %}
+            {% if node.name == model_name %}
+                {{ return(node.config) }}
+            {% endif %}            
+        {% endfor %}
+        {{ return(none) }}  
+    {% endif %}
+        {{ return(none) }}
+{% endmacro %}

--- a/dbt/macros/io.sql
+++ b/dbt/macros/io.sql
@@ -1,5 +1,20 @@
-{% macro export_table(model) %}
-  {% call statement(name, fetch_result=True) %}
-    COPY {{ model }} TO '../data/prep/{{ model.name }}.csv.gz' (HEADER, DELIMITER ',', COMPRESSION gzip)
-  {% endcall %}
+{#
+  Export a model to the prep folder in a CSV format.
+
+  Arguments:
+    - relation: the model to be exported.
+#}
+{% macro export_table(relation) %}
+
+  {% set model_config = get_model_config(relation.identifier) %}
+  {{ log(model_config) }}
+
+  {% if model_config.enabled %}
+      {% call statement(name, fetch_result=True) %}
+        COPY {{ relation }} TO '../data/prep/{{ model.name }}.csv.gz' (HEADER, DELIMITER ',', COMPRESSION gzip)
+      {% endcall %}
+  {% else %}
+      SELECT 1
+  {% endif %}
+
 {% endmacro %}

--- a/dbt/models/curated/player_valuations.sql
+++ b/dbt/models/curated/player_valuations.sql
@@ -1,3 +1,5 @@
+{{ config(enabled = false) }}
+
 with player_valuations_cte as (
 
     select * from {{ ref('base_player_valuations') }}


### PR DESCRIPTION
Relates to #215

### Summary
This PR disable updates on the `player_valuations` asset.

### Context
Given that an upstream change on Transfermark is currently blocking this asset (see #215), disabling will allow for at least the rest of the assets to work normally..