### PR TITLE
Extend upper limit for appearances row count

### DIFF
--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 94389e326f5a38ba8b725d1123c054a4.dir
-  size: 72551204
+- md5: 7fa18f2c60b4fa504c5a15cd95b62bf3.dir
+  size: 72860799
   nfiles: 10
   path: prep
   hash: md5

--- a/dbt/models/curated/models.yml
+++ b/dbt/models/curated/models.yml
@@ -23,7 +23,7 @@ models:
             - minutes_played
       - dbt_expectations.expect_table_row_count_to_be_between:
           min_value: 1000000
-          max_value: 1500000
+          max_value: 1600000
       
     columns:
       - name: appearance_id


### PR DESCRIPTION
The asset has grown and naturally overcome the defined range.

Fixes build https://github.com/dcaribou/transfermarkt-datasets/actions/runs/6860101124/job/18653374229