### PR TITLE
Add step for acquiring `game_lineups` to GA workflow

### DIFF
--- a/.github/workflows/acquire-transfermarkt-scraper.yml
+++ b/.github/workflows/acquire-transfermarkt-scraper.yml
@@ -33,30 +33,6 @@ jobs:
         with:
           name: clubs
           path: ${{ env.DATA_DIR }}/clubs.json.gz
-  
-  acquire-players:
-    runs-on: ubuntu-latest
-    container:
-      image: dcaribou/transfermarkt-datasets:linux-amd64-master
-    defaults:
-      run:
-        shell: bash -l {0}
-    needs: acquire-clubs
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: clubs
-          path: ${{ env.DATA_DIR }}
-      - name: run acquire
-        run: |
-          make \
-            acquire_local \
-              ARGS="--asset players --seasons $SEASON"
-      - uses: actions/upload-artifact@v3
-        with:
-          name: players
-          path: ${{ env.DATA_DIR }}/players.json.gz
 
   acquire-games:
     runs-on: ubuntu-latest
@@ -100,6 +76,30 @@ jobs:
         with:
           name: game_lineups
           path: ${{ env.DATA_DIR }}/game_lineups.json.gz
+
+  acquire-players:
+    runs-on: ubuntu-latest
+    container:
+      image: dcaribou/transfermarkt-datasets:linux-amd64-master
+    defaults:
+      run:
+        shell: bash -l {0}
+    needs: acquire-clubs
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: clubs
+          path: ${{ env.DATA_DIR }}
+      - name: run acquire
+        run: |
+          make \
+            acquire_local \
+              ARGS="--asset players --seasons $SEASON"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: players
+          path: ${{ env.DATA_DIR }}/players.json.gz
   
   acquire-appearances:
     runs-on: ubuntu-latest
@@ -133,10 +133,10 @@ jobs:
       run:
         shell: bash -l {0}
     needs:
-      - acquire-clubs
-      - acquire-players
       - acquire-games
       - acquire-game-lineups
+      - acquire-clubs
+      - acquire-players
       - acquire-appearances
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/acquire-transfermarkt-scraper.yml
+++ b/.github/workflows/acquire-transfermarkt-scraper.yml
@@ -76,6 +76,30 @@ jobs:
         with:
           name: games
           path: ${{ env.DATA_DIR }}/games.json.gz
+
+  acquire-game-lineups:
+    runs-on: ubuntu-latest
+    container:
+      image: dcaribou/transfermarkt-datasets:linux-amd64-master
+    defaults:
+      run:
+        shell: bash -l {0}
+    needs: acquire-games
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: games
+          path: ${{ env.DATA_DIR }}
+      - name: run acquire
+        run: |
+          make \
+            acquire_local \
+              ARGS="--asset game_lineups --seasons $SEASON"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: game_lineups
+          path: ${{ env.DATA_DIR }}/game_lineups.json.gz
   
   acquire-appearances:
     runs-on: ubuntu-latest
@@ -113,6 +137,7 @@ jobs:
       - acquire-players
       - acquire-games
       - acquire-appearances
+      - acquire-game-lineups
     steps:
       - uses: actions/checkout@v3
       - name: pull data
@@ -133,6 +158,10 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: appearances
+          path: ${{ env.DATA_DIR }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: game_lineups
           path: ${{ env.DATA_DIR }}
       - name: dvc commit and push
         run: |

--- a/.github/workflows/acquire-transfermarkt-scraper.yml
+++ b/.github/workflows/acquire-transfermarkt-scraper.yml
@@ -136,8 +136,8 @@ jobs:
       - acquire-clubs
       - acquire-players
       - acquire-games
-      - acquire-appearances
       - acquire-game-lineups
+      - acquire-appearances
     steps:
       - uses: actions/checkout@v3
       - name: pull data

--- a/.github/workflows/acquire-transfermarkt-scraper.yml
+++ b/.github/workflows/acquire-transfermarkt-scraper.yml
@@ -34,6 +34,30 @@ jobs:
           name: clubs
           path: ${{ env.DATA_DIR }}/clubs.json.gz
 
+  acquire-players:
+    runs-on: ubuntu-latest
+    container:
+      image: dcaribou/transfermarkt-datasets:linux-amd64-master
+    defaults:
+      run:
+        shell: bash -l {0}
+    needs: acquire-clubs
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: clubs
+          path: ${{ env.DATA_DIR }}
+      - name: run acquire
+        run: |
+          make \
+            acquire_local \
+              ARGS="--asset players --seasons $SEASON"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: players
+          path: ${{ env.DATA_DIR }}/players.json.gz
+
   acquire-games:
     runs-on: ubuntu-latest
     container:
@@ -52,7 +76,7 @@ jobs:
         with:
           name: games
           path: ${{ env.DATA_DIR }}/games.json.gz
-
+  
   acquire-game-lineups:
     runs-on: ubuntu-latest
     container:
@@ -77,30 +101,6 @@ jobs:
           name: game_lineups
           path: ${{ env.DATA_DIR }}/game_lineups.json.gz
 
-  acquire-players:
-    runs-on: ubuntu-latest
-    container:
-      image: dcaribou/transfermarkt-datasets:linux-amd64-master
-    defaults:
-      run:
-        shell: bash -l {0}
-    needs: acquire-clubs
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: clubs
-          path: ${{ env.DATA_DIR }}
-      - name: run acquire
-        run: |
-          make \
-            acquire_local \
-              ARGS="--asset players --seasons $SEASON"
-      - uses: actions/upload-artifact@v3
-        with:
-          name: players
-          path: ${{ env.DATA_DIR }}/players.json.gz
-  
   acquire-appearances:
     runs-on: ubuntu-latest
     container:
@@ -133,11 +133,11 @@ jobs:
       run:
         shell: bash -l {0}
     needs:
-      - acquire-games
-      - acquire-game-lineups
       - acquire-clubs
       - acquire-players
+      - acquire-games
       - acquire-appearances
+      - acquire-game-lineups
     steps:
       - uses: actions/checkout@v3
       - name: pull data


### PR DESCRIPTION
Mitigates #247

There seems to be an issue with job dependency rendering in Github Actions.

<img width="1463" alt="image" src="https://github.com/dcaribou/transfermarkt-datasets/assets/16071835/3a898b39-089f-4460-9d40-dfaacb7deffa">

For some reason it is adding a dependency between game-lineups and appearances that is not really defined in the YAML. We need to report it or ask for help here.

In any case, it does the job as it is.