### PR TITLE
Amend inconsistent `player_club_id`s in appearances

### DIFF
--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 9180c94abdea456f6cf01958ee0a3610.dir
-  size: 151799699
+- md5: a3c8d937314cd7050f0d274933577ae4.dir
+  size: 151948854
   nfiles: 10
   path: prep
   hash: md5

--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 1760e60307ee8eb9b6bcf3ab98e44dd0.dir
-  size: 151799869
+- md5: a3c8d937314cd7050f0d274933577ae4.dir
+  size: 151948854
   nfiles: 10
   path: prep
   hash: md5

--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 054c402f1ecab6647c33337c060b8319.dir
-  size: 75263436
+- md5: 1760e60307ee8eb9b6bcf3ab98e44dd0.dir
+  size: 151799869
   nfiles: 10
   path: prep
   hash: md5

--- a/data/prep.dvc
+++ b/data/prep.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: a3c8d937314cd7050f0d274933577ae4.dir
-  size: 151948854
+- md5: 9180c94abdea456f6cf01958ee0a3610.dir
+  size: 151799699
   nfiles: 10
   path: prep
   hash: md5

--- a/data/raw/transfermarkt-scraper.dvc
+++ b/data/raw/transfermarkt-scraper.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 2bc07ef7a3bf3c7de790c7b2046fc793.dir
-  size: 232002396
-  nfiles: 49
+- md5: 6b4383622d699b5829076a689dc27172.dir
+  size: 337859491
+  nfiles: 59
   hash: md5
   path: transfermarkt-scraper

--- a/dbt/macros/io.sql
+++ b/dbt/macros/io.sql
@@ -1,8 +1,8 @@
 {#
-  Export a model to the prep folder in a CSV format.
+    Export a model to the prep folder in a CSV format.
 
-  Arguments:
-    - relation: the model to be exported.
+    Arguments:
+      - relation: the model to be exported.
 #}
 {% macro export_table(relation) %}
 

--- a/dbt/models/base/transfermarkt_scraper/base_game_lineups.sql
+++ b/dbt/models/base/transfermarkt_scraper/base_game_lineups.sql
@@ -61,11 +61,11 @@ with
     all_game_lineups as (
 
         select * from home_club_starting_lineup
-        UNION ALL  
+        union
         select * from home_club_substitutes
-        UNION ALL
+        union
         select * from away_club_starting_lineup 
-        UNION ALL
+        union
         select * from away_club_substitutes
 
     )

--- a/dbt/models/curated/game_lineups.sql
+++ b/dbt/models/curated/game_lineups.sql
@@ -8,15 +8,13 @@ select
     {{ dbt_utils.generate_surrogate_key([
         'game_id',
         'player_id',
-        'club_id',
         'type',
-        'player_name',
         'position',
-        'team_captain',
-        'number'
+        'number',
+        'team_captain'
     ]) }} as game_lineups_id,
     game_lineups_cte.* 
 
 from game_lineups_cte
 
-order by game_id, club_id, "type"
+order by game_id, player_id, position, "number", team_captain, "type"

--- a/dbt/models/curated/models.yml
+++ b/dbt/models/curated/models.yml
@@ -303,7 +303,7 @@ models:
             - type
       - dbt_expectations.expect_table_row_count_to_be_between:
           min_value: 81000
-          max_value: 1340000
+          max_value: 2500000
     columns:
       - name: game_lineups_id
         tests:

--- a/dbt/tests/consistent_club_ids_in_appearances.sql
+++ b/dbt/tests/consistent_club_ids_in_appearances.sql
@@ -1,0 +1,23 @@
+{#
+    Sanity check to ensure that home and away club IDs are consistent within appearances.
+    This test tries to catch instances of the inconsitency reported in https://github.com/dcaribou/transfermarkt-datasets/issues/277.
+
+#}
+
+with appearances_cte as (
+
+    select * from {{ ref('appearances') }}
+
+),
+games_cte as (
+
+    select * from {{ ref('games') }}
+
+)
+-- get game IDs and club IDs from appearances and ensure that
+-- for each game ID, the clubs ID in appearances is either the home or away club ID from games
+
+select * 
+from appearances_cte
+left join games_cte on appearances_cte.game_id = games_cte.game_id
+where appearances_cte.player_club_id not in (games_cte.home_club_id, games_cte.away_club_id)


### PR DESCRIPTION
Fixes #277

**Bonus**
-  Added historical data for game lineups

This is also related to https://github.com/dcaribou/transfermarkt-scraper/issues/83, although that inconsistency is affecting the `game_lineups`, rather than `appearances`.