### PR TITLE
Transfer fix

### DIFF
--- a/transfermarkt_datasets/assets/cur_transfers.py
+++ b/transfermarkt_datasets/assets/cur_transfers.py
@@ -21,8 +21,8 @@ class CurTransfersAsset(RawAsset):
                 Field(name="player_name", type="string"),
                 Field(name="transfer_date", type="date"),
                 Field(name="transfer_season", type="string"),
-                Field(name="from_club_id", type="integer"),  # Добавлено
-                Field(name="to_club_id", type="integer"),    # Добавлено
+                Field(name="from_club_id", type="integer"),
+                Field(name="to_club_id", type="integer"),
                 Field(name="from_club_name", type="string", tags=["explore"]),
                 Field(name="to_club_name", type="string", tags=["explore"]),
                 Field(

--- a/transfermarkt_datasets/assets/cur_transfers.py
+++ b/transfermarkt_datasets/assets/cur_transfers.py
@@ -3,7 +3,6 @@ from frictionless import checks
 from transfermarkt_datasets.core.asset import RawAsset
 from transfermarkt_datasets.core.schema import Schema, Field
 
-
 class CurTransfersAsset(RawAsset):
     name = "cur_transfers"
     file_name = "transfers.csv.gz"
@@ -22,6 +21,8 @@ class CurTransfersAsset(RawAsset):
                 Field(name="player_name", type="string"),
                 Field(name="transfer_date", type="date"),
                 Field(name="transfer_season", type="string"),
+                Field(name="from_club_id", type="integer"),  # Добавлено
+                Field(name="to_club_id", type="integer"),    # Добавлено
                 Field(name="from_club_name", type="string", tags=["explore"]),
                 Field(name="to_club_name", type="string", tags=["explore"]),
                 Field(


### PR DESCRIPTION
I've added the 'from_club_id' and 'to_club_id' fields to the CurTransfersAsset schema. This was necessary because Streamlit was crashing due to a mismatch between the defined schema and the actual data in the CSV file. The error message indicated that these fields were present in the data but not in the schema. This update resolves the issue and allows the Streamlit app to load the transfers data correctly.