### PR TITLE
Increase player_valuations row count upper bound to 850000

### DIFF
--- a/dbt/models/curated/models.yml
+++ b/dbt/models/curated/models.yml
@@ -187,7 +187,7 @@ models:
             - player_club_domestic_competition_id
       - dbt_expectations.expect_table_row_count_to_be_between:
           min_value: 430000
-          max_value: 650000
+          max_value: 850000
     columns:
       - name: player_id
         tests:


### PR DESCRIPTION
The dataset has grown past the 650000 ceiling again, causing CI failures.
Commit 86f7466 reverted from 850000 to 650000 after fixing a data bug that
had temporarily inflated the count, but with weekly market value updates the
data has now naturally grown past 650000 again.

https://claude.ai/code/session_01KwD7WoqEEW8Sdi1muxjHKz