### PR TITLE
Bump row count upper bounds for games, club_games, and player_valuations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,23 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
-      - name: Run tests
+      - name: Pull data
+        run: just dvc_pull
+
+      - name: Run unit tests
+        run: just test
+
+      - name: Run dbt build
         run: |
-          set -e
-          just --set dbt_target prod dvc_pull test prepare_local
+          just --set dbt_target prod prepare_local 2>&1 | tee /tmp/dbt_output.log
+
+      - name: Show dbt test results on failure
+        if: failure()
+        run: |
+          echo '## dbt build output (last 80 lines)' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          tail -80 /tmp/dbt_output.log >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Export clean DuckDB file
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'

--- a/dbt/models/curated/models.yml
+++ b/dbt/models/curated/models.yml
@@ -235,7 +235,7 @@ models:
             - url
       - dbt_expectations.expect_table_row_count_to_be_between:
           min_value: 67000
-          max_value: 82000
+          max_value: 95000
     columns:
       - name: game_id
         tests:
@@ -280,7 +280,7 @@ models:
             - is_win
       - dbt_expectations.expect_table_row_count_to_be_between:
           min_value: 136000
-          max_value: 176000
+          max_value: 190000
 
   - name: game_events
     tests:

--- a/dbt/models/curated/models.yml
+++ b/dbt/models/curated/models.yml
@@ -187,7 +187,7 @@ models:
             - player_club_domestic_competition_id
       - dbt_expectations.expect_table_row_count_to_be_between:
           min_value: 430000
-          max_value: 650000
+          max_value: 850000
     columns:
       - name: player_id
         tests:


### PR DESCRIPTION
## Summary

The master build has been failing since the March 24 data update (commit 2f0ad69). The last passing build was on commit c4c4ac2 (March 23). The regular data acquisition plus the recently added Euro tournament games pushed multiple tables past their test thresholds.

- `player_valuations`: 650,000 → 850,000 (data grew past previous ceiling after 86f7466 reverted it)
- `games`: 82,000 → 95,000 (grew with Euro tournament games + regular weekly updates)
- `club_games`: 176,000 → 190,000 (proportional to games growth)

## Test plan

- [ ] CI build passes with the updated row count bounds
- [ ] Verify row counts are within the new ranges

https://claude.ai/code/session_01JCNzg11jxfNSqXVrQKn19D